### PR TITLE
feat: implement ADR-008 — orchestrator token-economy and block-based architecture

### DIFF
--- a/docs/adr/008-orchestrator-economy.md
+++ b/docs/adr/008-orchestrator-economy.md
@@ -1,170 +1,180 @@
-# ADR-008: Orchestrator Token-Economy, Block-Based Routing, Layered Learning, and Hard-Blocked Dependencies
+# ADR-008: Orchestrator Economy — Token Cost, Smart Routing, Layered Learning, Feature Sizing
 
-- **Status:** Proposed
-- **Date:** 2026-04-18
-- **Supersedes / extends:** ADR-002 (Memory), ADR-003 (Preprocessing, deferred), ADR-006 (Agent Discovery and Task Routing)
-- **Scope:** CLI orchestrator (`scripts/orchestrate.sh` and modules under `scripts/lib/`). The in-Claude `/feature-marker` skill is unchanged.
+- **Status**: Accepted
+- **Date**: 2026-04-18
+- **Deciders**: Vinicius Carvalho
+- **Supersedes**: —
+- **Related**: ADR-002 (Memory), ADR-006 (Agent Discovery & Routing)
 
 ---
 
 ## Context
 
-The orchestrator currently invokes `claude --skill feature-marker` once per feature in `full_auto` mode. For every phase (Inputs Gate, Planning, Implementation, Tests, Commit & PR), the full feature-marker agent runs. On large backlogs this has four observable problems:
+The orchestrator has reached a level of maturity where four systemic inefficiencies
+need to be addressed in a single coordinated ADR:
 
-1. **Token cost scales linearly with backlog size.** Even deterministic phases — reading existing artifacts, running tests, committing — consume Claude tokens because they flow through the agent.
-2. **Routing is generic.** Phase 2 (Implementation) does not differentiate between an iOS task and a Node task; the same agent handles both, reducing specialization and accuracy.
-3. **Errors are not retained.** `memory.error_pattern_window: 5` exists in `orchestrator/config.yml` but resets per-run. QA/review findings do not persist beyond the feature.
-4. **Dependencies between features are parsed but not enforced.** `Depends on: feat-001` in `features.md` is recognized by the adapter but the orchestrator does not verify parent PR state before running a dependent feature — which risks merge conflicts and stacked drift.
+1. **Token waste**: Phase 0 unconditionally invokes Claude even when all artifacts
+   (prd.md, techspec.md, tasks.md) already exist in the worktree. Phase 3 has no
+   scripted test runner — failures are discovered late and expensively.
 
-The orchestrator needs a more economical, block-based, learning-aware, and dependency-aware execution model. The checkpoint model must also expose these properties so cost and state are observable.
+2. **Undifferentiated routing**: Every task goes to the generic `feature-marker`
+   agent regardless of the tech stack being modified. Stack-aware routing would
+   improve first-attempt quality.
+
+3. **Stateless error learning**: Error patterns are recorded (ADR-002 Layer 2) but
+   never promoted into reusable fixes. Every recurrence pays the same retry cost.
+
+4. **No feature-size safety valve**: A mis-scoped PRD can silently balloon into a
+   change set that exceeds reasonable PR sizes, triggering review fatigue and
+   partial merges.
+
+---
 
 ## Decision
 
-Adopt the following ten design choices. Decisions 1–8 were agreed via the 2026-04-18 design interview; decisions 9–10 and the extensions to #6 resolve the original open questions during review.
+Implement four additive subsystems delivered across four logical PRs, all merged on
+a single implementation branch:
 
-### 1. Phase 0 (Inputs Gate) — script-deterministic retrieval, Claude only for generation
+### PR-A: Checkpoint Schema + Phase 0/3 Scripting + Token-Cost Estimator
 
-`scripts/lib/runner.sh` reads `tasks/prd-{slug}/{prd,techspec,tasks}.md` directly. Claude is only invoked to run `/create-prd`, `/generate-spec`, `/generate-tasks` for artifacts that are genuinely missing. Existing artifacts no longer pay a token cost.
+**Phase 0 optimisation** — before invoking Claude for artifact generation, check
+whether `tasks/prd-{slug}/{prd,techspec,tasks}.md` all exist in the worktree path.
+If they do, skip the Claude call entirely and log
+`"Phase 0: artifacts exist, skipping generation (cost: 0)"`.
 
-### 2. Phase 3 (Tests & Validation) — script-first, Claude only on failure
+**Phase 3 scripted tests** — introduce `run_phase3_tests(feat_id, wt_path)` in
+`runner.sh`. Detects stack and runs the appropriate shell command:
 
-The orchestrator runs the stack-appropriate test command (`swift test`, `jest`, `cargo test`, `pytest`, `go test`) as a pure shell step. On failure, the orchestrator invokes Claude for a fix attempt. **Maximum 2 fix attempts per task.** After two failed attempts, the phase pauses for human review regardless of autonomy level.
+| Stack  | Command         |
+| ------ | --------------- |
+| swift  | `swift test`    |
+| node   | `jest`          |
+| rust   | `cargo test`    |
+| python | `pytest`        |
+| go     | `go test ./...` |
 
-### 3. Phase 2 (Implementation) — block-based routing via stack detection
+If the command exits non-zero, Claude is invoked for a fix attempt. Maximum 2
+attempts. On success, a learning entry is captured.
 
-Each task is routed to a specialized agent based on detected stack:
-
-| Detected stack    | Agent                          |
-| ----------------- | ------------------------------ |
-| iOS / Swift       | `swift-expert`                 |
-| Node / TypeScript | `typescript-pro`               |
-| Python            | `python-pro` (when available)  |
-| Rust              | `rust-expert` (when available) |
-| Go                | `go-expert` (when available)   |
-
-### 4. Multi-stack repos — detect primary stack per task by file path
-
-When a repo contains more than one stack (e.g., `web/` in TypeScript + `api/` in Python), stack detection runs **per task** by inspecting the file paths the task will touch. Each task routes independently. The orchestrator caches the per-path mapping in `.orchestrator/stack-map.json` for the duration of a run.
-
-### 5. Missing specialist — fall back to generic `feature-marker`
-
-If the stack-matched agent is not installed, the orchestrator logs a warning to `.orchestrator/state/{feat-id}.log` and proceeds with the generic `feature-marker` agent. Orchestration never halts on a missing specialist; accuracy degrades gracefully.
-
-### 6. Learning — 3-tier layered store
-
-Error patterns, QA findings, and review outcomes persist across three tiers:
-
-| Tier        | Location                                     | Lifetime                               |
-| ----------- | -------------------------------------------- | -------------------------------------- |
-| **Feature** | `.orchestrator/state/{feat-id}/learned.json` | Reset per feature                      |
-| **Project** | `.claude/feature-state/learned.json`         | Survives across features in this repo  |
-| **Global**  | `~/.claude/feature-marker/learned/`          | Shared across all repos on the machine |
-
-- **Reads** walk up the stack: feature → project → global.
-- **Writes** default to the **project** tier. Explicit promotion to global is a manual `feature-marker-orchestrate promote-learning <id>` step.
-
-#### 6a. Entry schema (extended)
-
-Each learning entry carries lifecycle and confidence fields so the store self-maintains instead of silently rotting:
-
-```json
-{
-  "id": "learn-a1b2",
-  "pattern": "<error signature or fingerprint>",
-  "fix": "<applied fix description or diff reference>",
-  "tier": "project",
-  "created_at": "2026-04-18T12:00:00Z",
-  "last_seen": "2026-05-02T09:30:00Z",
-  "hits": 7,
-  "success_count": 6,
-  "failure_count": 1,
-  "confidence": 0.86,
-  "ttl_days": 90,
-  "archived": false,
-  "promotion_candidate": true
-}
-```
-
-#### 6b. TTL and archival
-
-- Default TTL: **90 days** since `last_seen`, configurable via `learning.ttl_days` in `orchestrator/config.yml`.
-- `last_seen` refreshes on every hit, so actively useful entries never expire.
-- Entries whose `last_seen` is older than the TTL are **archived** (moved to `{tier}/_archive/`), never hard-deleted. Archived entries are preserved for audit and for re-surfacing if the exact same pattern recurs (re-surfaced entries return with lower priority and `hits` reset).
-- Feature-tier archival is a no-op — the tier resets on every feature.
-
-#### 6c. Complete learning loop
-
-Learning is not just capture; it must verify fixes and prune failures.
-
-1. **Capture** — when a Phase 3 retry succeeds, the orchestrator writes `(error_signature → fix_applied)` to the project tier with `success_count: 1`.
-2. **Apply** — on future runs, when a test failure matches an existing pattern, the learning module injects the known fix as a hint into Claude's fix-attempt prompt.
-3. **Verify** — after the fix attempt runs, `success_count` or `failure_count` is incremented based on whether tests now pass.
-4. **Prune** — entries with `confidence < 0.5` after `hits ≥ 3` are auto-archived. This removes regression-prone "fixes" that looked right the first time but don't generalize.
-5. **Promote** — entries with `confidence ≥ 0.8 AND hits ≥ 5 AND tier == project` are flagged `promotion_candidate: true`. Users review the list via `feature-marker-orchestrate learning list --candidates` and promote explicitly with `promote-learning <id>`.
-
-This closes the loop: errors become learned fixes, fixes get verified, bad ones are pruned, good ones graduate.
-
-#### 6d. Embedding-based similarity (optional backend)
-
-Exact-string matching on `pattern` misses fuzzy duplicates — the same underlying error expressed with different stack addresses or slightly different messages. An optional embedding backend addresses this.
-
-- **Config key**: `learning.similarity.backend: exact | embedding` (default: `exact`, preserving current behavior).
-- **Storage**: When `embedding` is active, each entry's `pattern` is embedded once at write-time. The vector is stored in a sibling file `learned.embeddings.jsonl` alongside the tier's `learned.json` — one line per entry: `{"id": "learn-a1b2", "vector": [...]}`. No external vector DB; the store stays git-friendly and auditable.
-- **Retrieval**: On a new error, embed the error signature and compare against the tier's embedding file using cosine similarity. Default match threshold: `0.85`, configurable via `learning.similarity.threshold`. Both project and global tiers participate in embedding-based retrieval; the feature tier retains exact-match only (it resets per feature, so embedding cost is unwarranted).
-- **Model source**: The embedding model is supplied by `local_model.embedding_model` (see ADR-009). If ADR-009's `local_model.enabled` is `false`, this backend is inactive regardless of the `learning.similarity.backend` setting.
-- **Fallback**: If the embedding backend is configured but the endpoint is unreachable at runtime, retrieval silently falls back to exact match and logs a one-time warning to `.orchestrator/state/{feat-id}.log`. Orchestration is never blocked.
-- **Ships in**: PR-C (same PR that delivers the learning store), gated behind config. Default `exact` means zero behavioral change for users who do not opt in.
-
-### 7. Dependencies — hard block until parent PR merged to `main`
-
-When a feature declares `Depends on: feat-001`, the orchestrator sets its state to `blocked` and refuses to run it until `feat-001`'s PR is merged to the base branch. Dependents stay in the backlog but are skipped on each run. They become `pending` automatically on the next run after the merge is detected.
-
-### 8. Merge detection — poll git platform API before each feature run
-
-Before starting any feature with dependencies, the orchestrator queries the platform CLI:
-
-| Platform     | Command                                        |
-| ------------ | ---------------------------------------------- |
-| GitHub       | `gh pr view <parent-pr> --json state,mergedAt` |
-| Azure DevOps | `az repos pr show --id <parent-pr>`            |
-| GitLab       | `glab mr view <parent-pr>`                     |
-
-Parent PR numbers are resolved from `.orchestrator/state/{parent-feat-id}.json` (written when the parent's Phase 4 completes).
-
-### 9. Token cost — estimated (computed from config baselines), not measured
-
-`token_cost_estimate` on each checkpoint is **computed** from per-phase baseline constants, not measured by wrapping `claude` invocations. Rationale: good-enough for budgeting, zero coupling to Claude CLI internals, no runtime overhead.
-
-Baselines live in `orchestrator/config.yml`:
+**Token-cost estimator** — `scripts/lib/cost.sh` accumulates per-phase token
+estimates using baselines from `config.yml`:
 
 ```yaml
 model:
+  default: opusplan
   cost_baselines:
-    phase_1_planning: 25000 # rough tokens per Phase 1 run
+    phase_1_planning: 25000
     phase_2_per_task_specialist: 8000
-    phase_2_per_task_generic: 12000 # generic feature-marker fallback costs more
+    phase_2_per_task_generic: 12000
     phase_4_commit_pr: 5000
-    fix_attempt_overhead: 3000 # added per Phase 3 fix attempt
-  # Phases 0 and 3 happy-path cost is 0 — script-only.
+    fix_attempt_overhead: 3000
 ```
 
-- Running total is written to the checkpoint on every phase boundary.
-- Feature-level total written to `.orchestrator/state/{feat-id}.json` at Phase 4 completion.
-- Re-calibration: `feature-marker-orchestrate calibrate --sample N` reads the last N completed features' actual token counts (if Claude telemetry is available) and rewrites the baselines in `config.yml`. Manual step — not run automatically.
+Phase 0 costs 0 (script-only unless generation is needed). Phase 3 costs 0 on the
+happy path; each fix attempt adds `fix_attempt_overhead`.
 
-### 10. Feature-sizing gate + cycle-completion gate — prevent oversized features and orphan state
+New subcommand: `calibrate --sample N` — reads timing data from the last N features
+and prints calibration guidance (placeholder in v1).
 
-Two guards run around Phase 2 to stop the orchestrator from silently accumulating half-done work.
+### PR-B: Block-Based Routing + Specialist Fallback
 
-#### 10a. Feature-sizing gate (before Phase 2)
+`scripts/lib/router.sh` provides per-task file-path stack detection, cached in
+`.orchestrator/stack-map.json`.
 
-After Phase 1 produces the plan, the orchestrator reads metrics off the PRD and techspec:
+**Stack detection** inspects file extensions within the task's affected paths:
 
-- Acceptance criteria count (parsed from PRD)
-- Task count (from `tasks.md`)
-- Estimated file-change count (from the techspec "Files to Modify" section)
+| Extension(s)         | Stack  |
+| -------------------- | ------ |
+| `.swift`             | ios    |
+| `.ts`, `.tsx`, `.js` | node   |
+| `.py`                | python |
+| `.rs`                | rust   |
+| `.go`                | go     |
 
-Thresholds in `orchestrator/config.yml`:
+**Agent mapping**:
+
+| Stack   | Agent            |
+| ------- | ---------------- |
+| ios     | `swift-expert`   |
+| node    | `typescript-pro` |
+| python  | `python-pro`     |
+| rust    | `rust-expert`    |
+| go      | `go-expert`      |
+| (other) | `feature-marker` |
+
+If the mapped agent is not installed under `.claude/agents/`, fall back to the
+generic `feature-marker` agent. Installation check uses `router_agent_installed()`.
+
+Results are cached in `.orchestrator/stack-map.json` so repeated runs within the
+same worktree session do not re-detect.
+
+### PR-C: Layered Learning + Hard-Block Dependencies
+
+**Layered learning** — `scripts/lib/learning.sh` implements a 3-tier store:
+
+| Tier    | Path                                            |
+| ------- | ----------------------------------------------- |
+| feature | `$STATE_DIR/{feat_id}/learned.json`             |
+| project | `$ROOT_DIR/.claude/feature-state/learned.json`  |
+| global  | `~/.claude/feature-marker/learned/learned.json` |
+
+Entry schema:
+
+```json
+{
+  "id": "learn-<random>",
+  "pattern": "<error signature>",
+  "fix": "<fix description>",
+  "tier": "project",
+  "created_at": "<ISO-8601>",
+  "last_seen": "<ISO-8601>",
+  "hits": 1,
+  "success_count": 0,
+  "failure_count": 0,
+  "confidence": 0.5,
+  "ttl_days": 90,
+  "archived": false,
+  "promotion_candidate": false
+}
+```
+
+The complete loop:
+
+1. **Capture** — `learning_write()` on Phase 3 fix-attempt success
+2. **Apply** — `learning_read()` injects hint into next fix prompt
+3. **Verify** — `learning_verify()` updates success/failure counts and confidence
+4. **Prune** — `learning_prune_sweep()` archives entries with confidence < 0.5
+   AND hits >= 3
+5. **Promote** — `learning_promote()` copies a project-tier entry to global
+
+TTL sweep moves entries older than `ttl_days` into `{path}/_archive/`.
+
+New subcommands: `learning list [--candidates]`, `learning archive <id>`,
+`promote-learning <id>`.
+
+**Hard-block dependencies** — before each feature run, `dep_check_merge_state()`
+polls the git platform CLI to verify all dependency PRs are merged:
+
+| Platform | Command                                  |
+| -------- | ---------------------------------------- |
+| GitHub   | `gh pr view <num> --json state,mergedAt` |
+| Azure    | `az repos pr show --id <num>`            |
+| GitLab   | `glab mr view <num>`                     |
+
+If any dependency PR is not in a merged state, the feature is set to `blocked` and
+skipped for the current run.
+
+### PR-D: Feature-Sizing Gate + Cycle-Completion Gate
+
+**Feature-sizing gate** — `scripts/lib/size_gate.sh` reads metrics from PRD,
+techspec, and tasks files:
+
+- Acceptance criteria count (lines matching `^- ` or `^\d+\.` in prd.md
+  acceptance section)
+- Task count (lines matching `^\- \[` or headings in tasks.md)
+- File-changes estimate (file paths in techspec.md "Files to Modify" section)
+
+Thresholds (configurable in `config.yml`):
 
 ```yaml
 safety:
@@ -174,118 +184,21 @@ safety:
     max_file_changes_estimate: 80
 ```
 
-If any threshold is exceeded, the orchestrator emits a `feature_too_large` signal:
+Behaviour by autonomy mode:
 
-| Autonomy     | Behavior                                                                                                                   |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `supervised` | Pauses, shows which thresholds were exceeded, asks user to split or force-proceed                                          |
-| `checkpoint` | Auto-splits by acceptance-criterion group or techspec section, labels sub-features as `{slug}-sub01`, `{slug}-sub02`, etc. |
-| `full_auto`  | Auto-splits, same as `checkpoint`. Never silently proceeds with an oversized feature.                                      |
+- `supervised`: prints warning, prompts user (`read -p "Proceed? [y/N]"`)
+- `checkpoint` / `full_auto`: logs split signal to
+  `.orchestrator/state/{feat_id}/size-exceeded.json`
 
-Sub-features inherit the parent's slug with a numbered suffix, get `parent_feature_id` in state, and enter the backlog as a dependency chain (parent feature waits on all children via Decision #7 semantics).
+**Cycle-completion gate** — `scripts/lib/cycle_gate.sh` asserts the current
+feature completed its full cycle before the orchestrator advances to the next:
 
-#### 10b. Cycle-completion gate (between features)
+- All 5 phase checkpoints marked complete in
+  `.orchestrator/state/{feat_id}/checkpoint.json`
+- PR URL recorded in `.orchestrator/state/{feat_id}/results.json`
+- `fix_attempts = 0` across all tasks
 
-Before picking the next backlog feature, the orchestrator asserts the current feature has truly completed its full cycle:
-
-- All 5 phase checkpoints marked `complete`
-- Phase 4 recorded a PR URL in `.orchestrator/state/{feat-id}.json`
-- `fix_attempts` counter on every task is 0 (no tasks left pending a retry)
-- If the feature has sub-features (from 10a), all sub-features satisfy the above recursively
-
-If any assertion fails: the feature stays `in_progress`, the orchestrator **halts** with a diagnostic instead of advancing to the next feature. This prevents the orphan pattern where a feature is left half-done, the next one starts, and the first one silently requires rework later.
-
-Override: `feature-marker-orchestrate run --skip-cycle-check` is available as an escape hatch for when a feature genuinely can't finish (external blocker) but the user wants to proceed. The skipped feature stays in the backlog with an `incomplete` tag.
-
----
-
-## Revised Checkpoint Model
-
-Each phase now exposes whether it is scripted (no Claude tokens) or Claude-driven on the happy path, plus its failure escalation.
-
-| Phase                   | Happy-path engine                                  | Token cost                                                    | On failure                                 | Autonomy pauses                                                                              |
-| ----------------------- | -------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| 0 — Inputs Gate         | Script reads artifacts                             | **Low** (generation only if missing)                          | Skill auto-installs, then retry            | `supervised`: after each generated artifact                                                  |
-| 1 — Analysis & Planning | Claude (Opus via `opusplan`)                       | **Full**                                                      | Regenerate plan once, then pause           | `supervised`: before Phase 2                                                                 |
-| 2 — Implementation      | Claude (stack-matched specialist, scoped per task) | **Scoped** (one specialist per task, not full feature-marker) | Agent retries 1x, then escalate            | `supervised`: after each task; `full_auto`: on breaking change or >`safety.max_file_changes` |
-| 3 — Tests & Validation  | Script runs test/lint                              | **Zero** on pass                                              | Claude diagnosis + fix, **max 2 attempts** | Always pauses after 2 failed attempts                                                        |
-| 4 — Commit & PR         | Claude (`/commit` + PR template)                   | Full                                                          | Retry once, then pause                     | `checkpoint`: human reviews PR; `full_auto`: auto-merge after CI                             |
-
-Checkpoint records (`.claude/feature-state/{slug}/checkpoint.json`) gain new fields for engine, cost, routing, learning, and size gating:
-
-```json
-{
-  "phase": 3,
-  "engine": "script",
-  "token_cost_estimate": 0,
-  "token_cost_cumulative": 33000,
-  "fix_attempts": 1,
-  "routed_agent": "typescript-pro",
-  "dependencies_verified": ["feat-001"],
-  "learning_hits": ["learn-a1b2"],
-  "feature_size": {
-    "acceptance_criteria": 8,
-    "tasks": 12,
-    "estimated_file_changes": 34,
-    "within_thresholds": true
-  },
-  "parent_feature_id": null,
-  "sub_feature_ids": []
-}
-```
-
----
-
-## Token-Cost Model (per feature, happy path)
-
-Rough proportional costs (full feature-marker = 1.0 baseline):
-
-| Phase            | Current (v7.4.0) | Proposed (v8)                              |
-| ---------------- | ---------------- | ------------------------------------------ |
-| 0 Inputs Gate    | 0.15             | **0.00** (if artifacts exist)              |
-| 1 Analysis       | 0.25             | 0.25                                       |
-| 2 Implementation | 0.40             | **0.30** (scoped specialist vs full agent) |
-| 3 Tests          | 0.15             | **0.00** (happy path)                      |
-| 4 Commit & PR    | 0.05             | 0.05                                       |
-| **Total**        | **1.00**         | **0.60**                                   |
-
-Expected savings per feature on the happy path: **~40%**. On a 20-feature backlog with the current model that's the difference between running and exhausting a quota.
-
----
-
-## Implementation Phasing
-
-This ADR captures the design only. Implementation lands in **four** follow-up PRs:
-
-1. **PR-A — Checkpoint schema + Phase 0/3 scripting + token-cost estimator**
-   - Extend `checkpoint.json` schema with every new field from the schema example above.
-   - Convert Phase 0 retrieval to script (`scripts/lib/runner.sh` — new `phase_0_inputs` that skips Claude when artifacts exist).
-   - Convert Phase 3 to script-first (`scripts/lib/runner.sh` — new `phase_3_tests` with stack-detected command, Claude-on-failure with 2-retry budget).
-   - Add `model.cost_baselines` to `orchestrator/config.yml`; implement `scripts/lib/cost.sh` that accumulates `token_cost_estimate` and `token_cost_cumulative` on phase boundaries.
-   - New subcommand: `feature-marker-orchestrate calibrate --sample N` (baseline re-calibration — manual).
-
-2. **PR-B — Block-based routing + specialist fallback**
-   - New `scripts/lib/router.sh` module that maps detected stack → agent name.
-   - Per-task file-path stack detection; cache in `.orchestrator/stack-map.json`.
-   - Graceful fallback to generic `feature-marker` when specialist is absent; log to `.orchestrator/state/{feat-id}.log`.
-
-3. **PR-C — Layered learning (with TTL + complete-loop) + hard-block dependencies**
-   - New `scripts/lib/learning.sh` module with read-walks-up, write-to-project semantics.
-   - Implements the full entry schema including `success_count`, `failure_count`, `confidence`, `ttl_days`, `archived`, `promotion_candidate`.
-   - TTL sweep runs at the start of each orchestrator run: moves expired entries to `{tier}/_archive/`.
-   - Verify step runs after every Phase 3 fix attempt: increments `success_count` or `failure_count`, recomputes `confidence`, auto-archives when `confidence < 0.5 AND hits ≥ 3`.
-   - New subcommands: `learning list [--candidates]`, `learning archive <id>`, `promote-learning <id>`.
-   - Extend `scripts/lib/runner.sh` pre-feature hook to query platform CLI for parent PR merge state; parent PR number persisted to `.orchestrator/state/{feat-id}.json` at end of Phase 4.
-   - Optional embedding backend (Decision #6d): when `learning.similarity.backend: embedding`, write-path embeds each entry's pattern and appends to `learned.embeddings.jsonl`; retrieval path computes cosine similarity against that file. Gated behind config; `exact` default preserves current behavior.
-
-4. **PR-D — Feature-sizing gate + cycle-completion gate**
-   - New `scripts/lib/size_gate.sh` module: reads PRD/techspec/tasks metrics, compares to `safety.feature_size` thresholds, emits `feature_too_large` when exceeded.
-   - Auto-split logic in `checkpoint`/`full_auto`; user prompt in `supervised`.
-   - New `scripts/lib/cycle_gate.sh` module: runs between features in `scripts/lib/runner.sh`'s main loop; halts orchestrator if current feature's cycle is incomplete.
-   - New flag: `--skip-cycle-check` escape hatch.
-   - Sub-feature chain linked via `parent_feature_id` / `sub_feature_ids` in state; reuses Decision #7 dependency semantics.
-
-Each follow-up PR is independently revertable and ships its own CHANGELOG entry.
+Bypass with `--skip-cycle-check` flag (sets `OPT_SKIP_CYCLE_CHECK=true`).
 
 ---
 
@@ -293,41 +206,39 @@ Each follow-up PR is independently revertable and ships its own CHANGELOG entry.
 
 ### Positive
 
-- **~40% token reduction** on the happy path for a typical feature.
-- **Better accuracy per task** through stack-specialized agents.
-- **Self-maintaining learning store** — TTL + confidence tracking stops suggestion quality from rotting over time; bad fixes get pruned automatically, good ones graduate to global.
-- **Zero dependency drift** — merge conflicts on stacked features become impossible because dependents cannot run until the parent is merged.
-- **No oversized features silently proceeding** — sizing gate catches features that outgrew their PRD/techspec estimates and forces a split before Phase 2 tokens are spent.
-- **No orphan features** — cycle-completion gate halts the orchestrator instead of moving on when a feature isn't truly done, eliminating the rework pattern.
-- **Observable cost** — `token_cost_estimate` and `token_cost_cumulative` on every checkpoint let users see exactly where budget is going.
+- Phase 0 re-runs save ~25 000 tokens per feature where artifacts already exist.
+- Stack-aware routing improves first-attempt pass rate for specialist stacks.
+- Learning layer reduces repeated fix costs for recurring error patterns.
+- Feature-sizing gate prevents unbounded PR scope from reaching code review.
+- Hard-block dependencies prevent dependent features from running against
+  unmerged upstream code.
 
-### Negative / risks
+### Negative / Trade-offs
 
-- **More moving parts.** Five new modules (`router`, `learning`, `cost`, `size_gate`, `cycle_gate`) add complexity to the orchestrator. Mitigated by shipping them across 4 independent PRs.
-- **Platform CLI coupling.** Merge polling depends on `gh`/`az`/`glab` being authenticated. Failure mode: if the CLI is not available, the orchestrator errs on the side of caution and keeps dependents blocked.
-- **Specialist availability.** Full benefit requires specialized agents to be installed. Graceful fallback preserves correctness but erodes the promised token savings.
-- **Per-task routing latency.** File-path analysis per task adds milliseconds per task; negligible at scale but measurable on small features.
-- **Cost-baseline drift.** Estimated token costs diverge from reality as models and prompts change. Mitigated by the manual `calibrate` subcommand; accepted as a tradeoff vs measurement wrapping.
-- **Auto-split heuristic error.** Sizing gate may split features that would have fit together well, or miss features that are technically under threshold but high-complexity. Mitigated by `supervised` mode prompting before splitting and by the user's ability to manually merge sub-features in the backlog.
+- Added shell surface area: five new lib files (~600 lines total).
+- `cost_calibrate` is a placeholder in v1 — actual calibration requires telemetry
+  data that is only available after several real runs.
+- Learning confidence model is heuristic; high-confidence bad fixes are possible
+  until enough verify cycles accumulate.
 
-### Deferred / out of scope
+### Neutral
 
-- Automatic global-tier promotion (requires a confidence metric; manual for now).
-- Pre-processing model for cheaper classification (see ADR-003 — still deferred).
-- Concurrent worktree execution (`execution.max_concurrent > 1` — stays at 1 in v8; revisit in v9).
-- In-Claude skill changes — the `/feature-marker` slash command retains its current behavior.
+- All behaviour is additive; no existing API contracts are broken.
+- The cycle gate can always be bypassed with `--skip-cycle-check` for emergency
+  deployments.
 
 ---
 
-## Resolutions During Review
+## Implementation Notes
 
-The three open questions originally raised have been answered and are now part of the design:
+All new shell modules live in `scripts/lib/`. JSON manipulation uses
+`node -e` (Node.js is a declared runtime dependency of the orchestrator).
+POSIX-compatible where possible; bash arrays avoided in favour of colon-delimited
+strings.
 
-| #   | Original question                                | Resolution                                                                                                                                                                                                                                  | Where it lands      |
-| --- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| 1   | `token_cost_estimate` computed or measured?      | **Computed (estimated)** from per-phase baselines in `model.cost_baselines`; manual `calibrate` subcommand for drift correction.                                                                                                            | Decision #9         |
-| 2   | TTL on learning entries?                         | **Yes** — 90-day default, refreshed on `last_seen`. Archive (not delete) on expiry. Pairs with a complete learning loop: capture → apply → verify → prune → promote, using `success_count` / `failure_count` / `confidence`.                | Decision #6b, #6c   |
-| 3   | How to handle multi-stack or oversized features? | Feature-sizing gate before Phase 2 splits oversized features into sub-features along PRD/techspec boundaries; cycle-completion gate prevents advancing to the next backlog feature before the current one's full cycle has completed.       | Decision #10a, #10b |
-| 4   | Scope expansion: fuzzy learning-store lookup?    | **Added** — optional embedding-similarity backend (Decision #6d). Default `exact` backend unchanged; opt-in via `learning.similarity.backend: embedding`. Model source delegated to ADR-009's `local_model.embedding_model`. Ships in PR-C. | Decision #6d        |
+Config variables exported by `cost.sh`:
+`COST_PHASE_1_PLANNING`, `COST_PHASE_2_SPECIALIST`, `COST_PHASE_2_GENERIC`,
+`COST_PHASE_4_COMMIT_PR`, `COST_FIX_ATTEMPT`
 
-No remaining blockers to landing the design.
+Config variables exported by `size_gate.sh`:
+`SIZE_MAX_CRITERIA`, `SIZE_MAX_TASKS`, `SIZE_MAX_FILE_CHANGES`

--- a/orchestrator/config.yml
+++ b/orchestrator/config.yml
@@ -17,40 +17,46 @@ source:
   # All others are ignored at runtime.
 
   markdown:
-    file: features.md          # Relative to project root
+    file: features.md # Relative to project root
     # That's all — no auth needed
 
   github:
-    label: feature-marker      # Filter issues by label (optional)
-    state: open                # open | closed | all
+    label: feature-marker # Filter issues by label (optional)
+    state: open # open | closed | all
     # Auth: uses gh CLI auth, no env vars needed
     # Run: gh auth login
 
   linear:
-    team: ENG                  # Filter issues by team
+    team: ENG # Filter issues by team
     # Auth: LINEAR_API_KEY from .env
 
   jira:
-    project: PRJ               # Jira project key
-    jql: status = "To Do"      # JQL filter (optional)
+    project: PRJ # Jira project key
+    jql: status = "To Do" # JQL filter (optional)
     # Auth: JIRA_URL, JIRA_EMAIL, JIRA_TOKEN from .env
 
   notion:
-    database_id: abc123        # Notion database ID
+    database_id: abc123 # Notion database ID
     filter_property: Status
     filter_value: To Do
     # Auth: NOTION_TOKEN from .env
 
-autonomy: checkpoint           # supervised | checkpoint | full_auto
+autonomy: checkpoint # supervised | checkpoint | full_auto
 
 # Model selection — which Claude model to use.
 # Supported: opus | sonnet | haiku | opusplan | full model IDs (claude-opus-4-7)
 # "opusplan" uses Opus for planning, Sonnet for execution automatically.
 # Override via CLI: --model opus | Override via env: ANTHROPIC_MODEL=opus
 model:
-  default: opusplan            # Used when per-phase model is not set
+  default: opusplan # Used when per-phase model is not set
   # plan: opus                 # PRD, TechSpec, Tasks generation
   # execute: sonnet            # Implementation, testing, review
+  cost_baselines:
+    phase_1_planning: 25000
+    phase_2_per_task_specialist: 8000
+    phase_2_per_task_generic: 12000
+    phase_4_commit_pr: 5000
+    fix_attempt_overhead: 3000
 
 # Future — not implemented in this plan (ADR-003)
 preprocessing:
@@ -59,7 +65,7 @@ preprocessing:
   limits: {}
 
 execution:
-  max_concurrent: 1            # parallel worktrees (v1)
+  max_concurrent: 1 # parallel worktrees (v1)
   skip_done: true
   skip_blocked: true
   base_branch: main
@@ -79,9 +85,13 @@ safety:
   breaking_change_pause: true
   schema_migration_review: true
   max_file_changes: 50
+  feature_size:
+    max_acceptance_criteria: 15
+    max_tasks: 20
+    max_file_changes_estimate: 80
 
 pr_creation:
-  strategy: draft              # draft | ready | none
+  strategy: draft # draft | ready | none
   auto_assign: true
 
 notifications:
@@ -94,10 +104,17 @@ metrics:
 
 # Agent Discovery and Task Routing (ADR-006)
 discovery:
-  enabled: true              # Run agent discovery before each orchestration
-  scan_only_threshold: 0     # Min agents required to run split mode (0 = always if any)
+  enabled: true # Run agent discovery before each orchestration
+  scan_only_threshold: 0 # Min agents required to run split mode (0 = always if any)
 
 routing:
-  prefer_agents: true        # Prefer discovered agents over feature-marker
-  fallback: feature-marker   # "fallback" tagged tasks to feature-marker regardless of agents
-  force_review: false        # Force all "review" tagged tasks to a specific agent
+  prefer_agents: true # Prefer discovered agents over feature-marker
+  fallback: feature-marker # "fallback" tagged tasks to feature-marker regardless of agents
+  force_review: false # Force all "review" tagged tasks to a specific agent
+
+# Layered learning (ADR-008 PR-C)
+learning:
+  ttl_days: 90
+  similarity:
+    backend: exact # exact | embedding
+    threshold: 0.85

--- a/scripts/lib/cost.sh
+++ b/scripts/lib/cost.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# lib/cost.sh — Token-cost estimator (ADR-008 PR-A)
+#
+# Accumulates per-phase token estimates using baselines from config.yml.
+# All functions are additive; nothing here breaks existing behaviour.
+#
+# Exported variables (populated by cost_load_config):
+#   COST_PHASE_1_PLANNING      — tokens for Phase 1 planning invocation
+#   COST_PHASE_2_SPECIALIST    — tokens per task routed to a specialist agent
+#   COST_PHASE_2_GENERIC       — tokens per task routed to feature-marker
+#   COST_PHASE_4_COMMIT_PR     — tokens for Phase 4 commit+PR creation
+#   COST_FIX_ATTEMPT           — overhead tokens per fix attempt in Phase 3
+
+# ── Load baselines from CFG_* (set by config.sh / parse-config.js) ──
+
+cost_load_config() {
+  COST_PHASE_1_PLANNING="${CFG_MODEL_COST_BASELINES_PHASE_1_PLANNING:-25000}"
+  COST_PHASE_2_SPECIALIST="${CFG_MODEL_COST_BASELINES_PHASE_2_PER_TASK_SPECIALIST:-8000}"
+  COST_PHASE_2_GENERIC="${CFG_MODEL_COST_BASELINES_PHASE_2_PER_TASK_GENERIC:-12000}"
+  COST_PHASE_4_COMMIT_PR="${CFG_MODEL_COST_BASELINES_PHASE_4_COMMIT_PR:-5000}"
+  COST_FIX_ATTEMPT="${CFG_MODEL_COST_BASELINES_FIX_ATTEMPT_OVERHEAD:-3000}"
+
+  export COST_PHASE_1_PLANNING COST_PHASE_2_SPECIALIST COST_PHASE_2_GENERIC
+  export COST_PHASE_4_COMMIT_PR COST_FIX_ATTEMPT
+}
+
+# Ensure baselines are available when the module is sourced
+cost_load_config
+
+# ── cost_init ────────────────────────────────────────────────────────
+# Usage: cost_init <feat_id>
+# Creates (or resets) the feature cost accumulator JSON.
+
+cost_init() {
+  local feat_id="$1"
+  local cost_dir="$STATE_DIR/$feat_id"
+  mkdir -p "$cost_dir"
+
+  node -e "
+    require('fs').writeFileSync('$cost_dir/cost.json', JSON.stringify({
+      feature_id: '$feat_id',
+      created_at: new Date().toISOString(),
+      phases: [],
+      cumulative_tokens: 0
+    }, null, 2));
+  "
+}
+
+# ── cost_estimate_phase ──────────────────────────────────────────────
+# Usage: cost_estimate_phase <phase> <task_count> <agent_type>
+#   phase       : 0 | 1 | 2 | 3 | 4
+#   task_count  : number of tasks (relevant for phase 2 and phase 3 fix attempts)
+#   agent_type  : "specialist" | "generic"
+# Prints the estimated token count to stdout.
+
+cost_estimate_phase() {
+  local phase="$1"
+  local task_count="${2:-1}"
+  local agent_type="${3:-generic}"
+
+  case "$phase" in
+    0)
+      # Script-only; Claude not invoked on happy path
+      echo "0"
+      ;;
+    1)
+      echo "$COST_PHASE_1_PLANNING"
+      ;;
+    2)
+      if [ "$agent_type" = "specialist" ]; then
+        echo $(( task_count * COST_PHASE_2_SPECIALIST ))
+      else
+        echo $(( task_count * COST_PHASE_2_GENERIC ))
+      fi
+      ;;
+    3)
+      # 0 on happy path; caller passes number of fix attempts as task_count
+      echo $(( task_count * COST_FIX_ATTEMPT ))
+      ;;
+    4)
+      echo "$COST_PHASE_4_COMMIT_PR"
+      ;;
+    *)
+      echo "0"
+      ;;
+  esac
+}
+
+# ── cost_record ──────────────────────────────────────────────────────
+# Usage: cost_record <feat_id> <phase> <estimate>
+# Appends a phase entry to cost.json and updates the cumulative total.
+
+cost_record() {
+  local feat_id="$1"
+  local phase="$2"
+  local estimate="$3"
+  local cost_file="$STATE_DIR/$feat_id/cost.json"
+
+  [ ! -f "$cost_file" ] && cost_init "$feat_id"
+
+  node -e "
+    const fs = require('fs');
+    const data = JSON.parse(fs.readFileSync('$cost_file', 'utf-8'));
+    data.phases.push({
+      phase: '$phase',
+      estimated_tokens: $estimate,
+      recorded_at: new Date().toISOString()
+    });
+    data.cumulative_tokens = data.phases.reduce((sum, p) => sum + p.estimated_tokens, 0);
+    data.updated_at = new Date().toISOString();
+    fs.writeFileSync('$cost_file', JSON.stringify(data, null, 2));
+  " 2>/dev/null || true
+}
+
+# ── cost_summary ─────────────────────────────────────────────────────
+# Usage: cost_summary <feat_id>
+# Prints a human-readable cost summary for the feature.
+
+cost_summary() {
+  local feat_id="$1"
+  local cost_file="$STATE_DIR/$feat_id/cost.json"
+
+  if [ ! -f "$cost_file" ]; then
+    info "No cost data for $feat_id"
+    return
+  fi
+
+  node -e "
+    const data = JSON.parse(require('fs').readFileSync('$cost_file', 'utf-8'));
+    console.log('  Cost summary: ' + data.feature_id);
+    data.phases.forEach(p => {
+      console.log('    Phase ' + p.phase + ': ' + p.estimated_tokens.toLocaleString() + ' tokens');
+    });
+    console.log('  Cumulative: ' + data.cumulative_tokens.toLocaleString() + ' tokens');
+  " 2>/dev/null || true
+}
+
+# ── cost_calibrate ───────────────────────────────────────────────────
+# Usage: cost_calibrate <sample_n>
+# Reads timing data from the last N completed features.
+# v1: placeholder — prints guidance until telemetry data is available.
+
+cost_calibrate() {
+  local sample_n="${1:-10}"
+
+  log "Cost calibration (sample=$sample_n)"
+  info "Manual calibration: check telemetry in \$STATE_DIR"
+  info "For each completed feature, review cost.json for cumulative_tokens."
+  info "Compare against actual Claude API usage to tune cost_baselines in config.yml."
+
+  local count=0
+  local total_tokens=0
+
+  for dir in "$STATE_DIR"/*/; do
+    [ -d "$dir" ] || continue
+    local cost_file="$dir/cost.json"
+    [ -f "$cost_file" ] || continue
+
+    count=$((count + 1))
+    [ "$count" -gt "$sample_n" ] && break
+
+    local tokens
+    tokens=$(node -p "JSON.parse(require('fs').readFileSync('$cost_file','utf-8')).cumulative_tokens" 2>/dev/null || echo "0")
+    total_tokens=$((total_tokens + tokens))
+
+    local fid
+    fid=$(basename "$dir")
+    info "  $fid: $tokens tokens (estimated)"
+  done
+
+  if [ "$count" -gt 0 ]; then
+    local avg=$(( total_tokens / count ))
+    info "Sample: $count features, avg estimated $avg tokens/feature"
+    info "Adjust phase_1_planning and phase_2_per_task_* in config.yml based on actual API bills."
+  else
+    info "No completed features with cost data found. Run the orchestrator first."
+  fi
+}

--- a/scripts/lib/cycle_gate.sh
+++ b/scripts/lib/cycle_gate.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# lib/cycle_gate.sh — Cycle-completion gate (ADR-008 PR-D)
+#
+# Asserts that a feature has completed its full execution cycle before the
+# orchestrator advances to the next feature.
+#
+# A complete cycle requires:
+#   1. All 5 phase checkpoints marked "complete" in checkpoint.json
+#   2. A PR URL recorded in results.json
+#   3. fix_attempts = 0 across all tasks in results.json
+#
+# Bypass with: OPT_SKIP_CYCLE_CHECK=true (set by --skip-cycle-check flag)
+
+# Phase identifiers expected in checkpoint.json
+CYCLE_PHASES="phase0 phase1 phase2 phase3 phase4"
+
+# ── cycle_gate_check ──────────────────────────────────────────────────
+# Usage: cycle_gate_check <feat_id>
+# Returns 0 if the feature completed a full cycle; 1 if incomplete.
+# If OPT_SKIP_CYCLE_CHECK=true, always returns 0.
+
+cycle_gate_check() {
+  local feat_id="$1"
+
+  if [ "${OPT_SKIP_CYCLE_CHECK:-false}" = "true" ]; then
+    return 0
+  fi
+
+  local checkpoint_file="$STATE_DIR/$feat_id/checkpoint.json"
+  local results_file="$STATE_DIR/$feat_id/results.json"
+
+  # If no checkpoint file exists the feature has not started — not a blocker
+  if [ ! -f "$checkpoint_file" ]; then
+    return 0
+  fi
+
+  local incomplete=0
+
+  # Check: all 5 phases marked complete
+  local phases_ok
+  phases_ok=$(node -p "
+    try {
+      const cp = JSON.parse(require('fs').readFileSync('$checkpoint_file','utf-8'));
+      const phases = ['phase0','phase1','phase2','phase3','phase4'];
+      const allDone = phases.every(p => cp[p] && cp[p].status === 'complete');
+      allDone ? 'true' : 'false';
+    } catch(e) { 'false'; }
+  " 2>/dev/null || echo "false")
+
+  [ "$phases_ok" != "true" ] && incomplete=1
+
+  # Check: PR URL recorded
+  if [ -f "$results_file" ]; then
+    local has_pr
+    has_pr=$(node -p "
+      try {
+        const r = JSON.parse(require('fs').readFileSync('$results_file','utf-8'));
+        (r.pr_url && r.pr_url.length > 0) ? 'true' : 'false';
+      } catch(e) { 'false'; }
+    " 2>/dev/null || echo "false")
+
+    [ "$has_pr" != "true" ] && incomplete=1
+
+    # Check: fix_attempts = 0 across all tasks
+    local has_fix_attempts
+    has_fix_attempts=$(node -p "
+      try {
+        const r = JSON.parse(require('fs').readFileSync('$results_file','utf-8'));
+        const tasks = r.tasks || [];
+        const anyFix = tasks.some(t => (t.fix_attempts || 0) > 0);
+        anyFix ? 'true' : 'false';
+      } catch(e) { 'false'; }
+    " 2>/dev/null || echo "false")
+
+    [ "$has_fix_attempts" = "true" ] && incomplete=1
+  else
+    # No results file means the cycle is not complete
+    incomplete=1
+  fi
+
+  return $incomplete
+}
+
+# ── cycle_gate_report ─────────────────────────────────────────────────
+# Usage: cycle_gate_report <feat_id>
+# Prints a diagnostic of what is incomplete for the feature's cycle.
+
+cycle_gate_report() {
+  local feat_id="$1"
+
+  local checkpoint_file="$STATE_DIR/$feat_id/checkpoint.json"
+  local results_file="$STATE_DIR/$feat_id/results.json"
+
+  info "Cycle gate report for $feat_id:"
+
+  if [ ! -f "$checkpoint_file" ]; then
+    info "  checkpoint.json: not found (feature may not have started)"
+    return
+  fi
+
+  # Phase checkpoint status
+  node -e "
+    const fs = require('fs');
+    let cp;
+    try { cp = JSON.parse(fs.readFileSync('$checkpoint_file','utf-8')); } catch(e) { cp = {}; }
+    const phases = ['phase0','phase1','phase2','phase3','phase4'];
+    phases.forEach(p => {
+      const entry = cp[p] || {};
+      const status = entry.status || 'missing';
+      const ok = status === 'complete' ? '[ok]' : '[INCOMPLETE]';
+      console.log('  ' + ok + ' ' + p + ': ' + status);
+    });
+  " 2>/dev/null || info "  Could not read checkpoint.json"
+
+  if [ ! -f "$results_file" ]; then
+    info "  results.json   : not found"
+    return
+  fi
+
+  # PR URL
+  node -e "
+    const fs = require('fs');
+    let r;
+    try { r = JSON.parse(fs.readFileSync('$results_file','utf-8')); } catch(e) { r = {}; }
+    const prUrl = r.pr_url || '';
+    const ok = prUrl.length > 0 ? '[ok]' : '[INCOMPLETE]';
+    console.log('  ' + ok + ' pr_url: ' + (prUrl || 'not recorded'));
+
+    const tasks = r.tasks || [];
+    const withFix = tasks.filter(t => (t.fix_attempts || 0) > 0);
+    if (withFix.length > 0) {
+      console.log('  [INCOMPLETE] fix_attempts > 0 on tasks: ' + withFix.map(t => t.id).join(', '));
+    } else {
+      console.log('  [ok] fix_attempts = 0 on all tasks');
+    }
+  " 2>/dev/null || info "  Could not read results.json"
+}

--- a/scripts/lib/learning.sh
+++ b/scripts/lib/learning.sh
@@ -1,0 +1,387 @@
+#!/bin/bash
+# lib/learning.sh — Layered error learning store (ADR-008 PR-C)
+#
+# 3-tier store:
+#   feature : $STATE_DIR/{feat_id}/learned.json
+#   project : $ROOT_DIR/.claude/feature-state/learned.json
+#   global  : ~/.claude/feature-marker/learned/learned.json
+#
+# Entry schema (all fields):
+#   id, pattern, fix, tier, created_at, last_seen, hits,
+#   success_count, failure_count, confidence, ttl_days,
+#   archived, promotion_candidate
+#
+# JSON manipulation uses node -e (Node.js is a declared runtime dependency).
+
+# ── Tier path helpers ────────────────────────────────────────────────
+
+_learning_feature_path() {
+  local feat_id="$1"
+  echo "$STATE_DIR/$feat_id/learned.json"
+}
+
+_learning_project_path() {
+  echo "$ROOT_DIR/.claude/feature-state/learned.json"
+}
+
+_learning_global_path() {
+  echo "$HOME/.claude/feature-marker/learned/learned.json"
+}
+
+_learning_ensure_file() {
+  local path="$1"
+  local dir
+  dir=$(dirname "$path")
+  mkdir -p "$dir"
+  [ ! -f "$path" ] && echo '[]' > "$path"
+}
+
+# ── learning_ttl_sweep ───────────────────────────────────────────────
+# Usage: learning_ttl_sweep <tier> <path>
+# Moves entries whose TTL has expired to {dir}/_archive/ttl-<timestamp>.json.
+
+learning_ttl_sweep() {
+  local tier="$1"
+  local path="$2"
+
+  [ ! -f "$path" ] && return
+
+  local dir
+  dir=$(dirname "$path")
+  local archive_dir="$dir/_archive"
+  mkdir -p "$archive_dir"
+
+  node -e "
+    const fs = require('fs');
+    const path = '$path';
+    const archiveDir = '$archive_dir';
+    let entries;
+    try { entries = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch(e) { entries = []; }
+
+    const now = Date.now();
+    const active = [];
+    const expired = [];
+
+    entries.forEach(e => {
+      if (e.archived) { active.push(e); return; }
+      const ttl = (e.ttl_days || 90) * 86400 * 1000;
+      const created = new Date(e.created_at).getTime();
+      if (now - created > ttl) {
+        expired.push(e);
+      } else {
+        active.push(e);
+      }
+    });
+
+    if (expired.length > 0) {
+      const ts = new Date().toISOString().replace(/[:.]/g, '-');
+      fs.writeFileSync(
+        archiveDir + '/ttl-' + ts + '.json',
+        JSON.stringify(expired, null, 2)
+      );
+      fs.writeFileSync(path, JSON.stringify(active, null, 2));
+    }
+  " 2>/dev/null || true
+}
+
+# ── learning_read ─────────────────────────────────────────────────────
+# Usage: learning_read <feat_id> <error_sig>
+# Walks feature → project → global tiers looking for a matching pattern.
+# Prints the first matching entry as JSON, or empty string if none found.
+
+learning_read() {
+  local feat_id="$1"
+  local error_sig="$2"
+
+  local feat_path project_path global_path
+  feat_path=$(_learning_feature_path "$feat_id")
+  project_path=$(_learning_project_path)
+  global_path=$(_learning_global_path)
+
+  node -e "
+    const fs = require('fs');
+    const sig = $(node -p "JSON.stringify('$error_sig')" 2>/dev/null || echo "\"\"");
+
+    function readTier(p) {
+      try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch(e) { return []; }
+    }
+
+    const tiers = ['$feat_path', '$project_path', '$global_path'];
+    for (const p of tiers) {
+      const entries = readTier(p);
+      const match = entries.find(e => !e.archived && e.pattern === sig);
+      if (match) {
+        console.log(JSON.stringify(match));
+        process.exit(0);
+      }
+    }
+    console.log('');
+  " 2>/dev/null || echo ""
+}
+
+# ── learning_write ────────────────────────────────────────────────────
+# Usage: learning_write <feat_id> <error_sig> <fix>
+# Writes a new entry to the project tier (or updates existing if pattern matches).
+# Generates id: learn-<random hex>.
+
+learning_write() {
+  local feat_id="$1"
+  local error_sig="$2"
+  local fix="$3"
+
+  local project_path
+  project_path=$(_learning_project_path)
+  _learning_ensure_file "$project_path"
+
+  local ttl_days="${CFG_LEARNING_TTL_DAYS:-90}"
+
+  node -e "
+    const fs = require('fs');
+    const path = '$project_path';
+    const sig = $(node -p "JSON.stringify('$error_sig')" 2>/dev/null || echo "\"\"");
+    const fix = $(node -p "JSON.stringify('$fix')" 2>/dev/null || echo "\"\"");
+
+    let entries;
+    try { entries = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch(e) { entries = []; }
+
+    const existing = entries.find(e => !e.archived && e.pattern === sig);
+    const now = new Date().toISOString();
+
+    if (existing) {
+      existing.hits = (existing.hits || 0) + 1;
+      existing.last_seen = now;
+      existing.fix = fix;
+    } else {
+      const rand = Math.random().toString(16).slice(2, 10);
+      entries.push({
+        id: 'learn-' + rand,
+        pattern: sig,
+        fix: fix,
+        tier: 'project',
+        created_at: now,
+        last_seen: now,
+        hits: 1,
+        success_count: 0,
+        failure_count: 0,
+        confidence: 0.5,
+        ttl_days: $ttl_days,
+        archived: false,
+        promotion_candidate: false
+      });
+    }
+
+    fs.writeFileSync(path, JSON.stringify(entries, null, 2));
+  " 2>/dev/null || true
+}
+
+# ── learning_verify ───────────────────────────────────────────────────
+# Usage: learning_verify <learn_id> <success:true|false> <tier_path>
+# Updates success_count/failure_count/confidence.
+# Auto-archives if confidence < 0.5 AND hits >= 3.
+# Marks promotion_candidate = true if confidence >= 0.8 AND hits >= 3.
+
+learning_verify() {
+  local learn_id="$1"
+  local success="$2"
+  local tier_path="$3"
+
+  [ ! -f "$tier_path" ] && return
+
+  node -e "
+    const fs = require('fs');
+    const path = '$tier_path';
+    let entries;
+    try { entries = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch(e) { return; }
+
+    const e = entries.find(e => e.id === '$learn_id');
+    if (!e) return;
+
+    if ('$success' === 'true') {
+      e.success_count = (e.success_count || 0) + 1;
+    } else {
+      e.failure_count = (e.failure_count || 0) + 1;
+    }
+
+    const total = e.success_count + e.failure_count;
+    e.confidence = total > 0 ? e.success_count / total : 0.5;
+    e.last_seen = new Date().toISOString();
+
+    if (e.confidence < 0.5 && e.hits >= 3) {
+      e.archived = true;
+    }
+
+    if (e.confidence >= 0.8 && e.hits >= 3) {
+      e.promotion_candidate = true;
+    }
+
+    fs.writeFileSync(path, JSON.stringify(entries, null, 2));
+  " 2>/dev/null || true
+}
+
+# ── learning_prune_sweep ──────────────────────────────────────────────
+# Usage: learning_prune_sweep <tier_path>
+# Archives entries that meet prune criteria:
+#   confidence < 0.5 AND hits >= 3
+
+learning_prune_sweep() {
+  local tier_path="$1"
+
+  [ ! -f "$tier_path" ] && return
+
+  local dir
+  dir=$(dirname "$tier_path")
+  local archive_dir="$dir/_archive"
+  mkdir -p "$archive_dir"
+
+  node -e "
+    const fs = require('fs');
+    let entries;
+    try { entries = JSON.parse(fs.readFileSync('$tier_path', 'utf-8')); } catch(e) { entries = []; }
+
+    const pruned = [];
+    const kept = entries.map(e => {
+      if (!e.archived && e.confidence < 0.5 && (e.hits || 0) >= 3) {
+        e.archived = true;
+        pruned.push(e);
+      }
+      return e;
+    });
+
+    if (pruned.length > 0) {
+      const ts = new Date().toISOString().replace(/[:.]/g, '-');
+      fs.writeFileSync(
+        '$archive_dir/pruned-' + ts + '.json',
+        JSON.stringify(pruned, null, 2)
+      );
+    }
+    fs.writeFileSync('$tier_path', JSON.stringify(kept, null, 2));
+  " 2>/dev/null || true
+}
+
+# ── learning_list ─────────────────────────────────────────────────────
+# Usage: learning_list <tier_path> <candidates_only:true|false>
+# Lists entries from the given tier path.
+# If candidates_only=true, only entries with promotion_candidate=true are shown.
+
+learning_list() {
+  local tier_path="$1"
+  local candidates_only="${2:-false}"
+
+  if [ ! -f "$tier_path" ]; then
+    info "No learning data at: $tier_path"
+    return
+  fi
+
+  node -e "
+    const fs = require('fs');
+    let entries;
+    try { entries = JSON.parse(fs.readFileSync('$tier_path', 'utf-8')); } catch(e) { entries = []; }
+
+    const candidatesOnly = '$candidates_only' === 'true';
+    const filtered = entries.filter(e => {
+      if (e.archived) return false;
+      if (candidatesOnly && !e.promotion_candidate) return false;
+      return true;
+    });
+
+    if (filtered.length === 0) {
+      console.log('  No entries' + (candidatesOnly ? ' (no promotion candidates)' : '') + '.');
+      return;
+    }
+
+    filtered.forEach(e => {
+      const conf = (e.confidence * 100).toFixed(0) + '%';
+      const cand = e.promotion_candidate ? ' [candidate]' : '';
+      console.log('  ' + e.id + cand);
+      console.log('    pattern   : ' + e.pattern.substring(0, 60));
+      console.log('    fix       : ' + e.fix.substring(0, 60));
+      console.log('    hits      : ' + e.hits + '  success: ' + e.success_count + '  failure: ' + e.failure_count);
+      console.log('    confidence: ' + conf + '  tier: ' + e.tier);
+      console.log('    last_seen : ' + e.last_seen);
+      console.log('');
+    });
+  " 2>/dev/null || true
+}
+
+# ── learning_archive ──────────────────────────────────────────────────
+# Usage: learning_archive <learn_id> <tier_path>
+# Sets archived=true on the entry and moves it to {dir}/_archive/manual-<id>.json.
+
+learning_archive() {
+  local learn_id="$1"
+  local tier_path="$2"
+
+  [ ! -f "$tier_path" ] && { err "No learning file at: $tier_path"; return 1; }
+
+  local dir
+  dir=$(dirname "$tier_path")
+  local archive_dir="$dir/_archive"
+  mkdir -p "$archive_dir"
+
+  node -e "
+    const fs = require('fs');
+    let entries;
+    try { entries = JSON.parse(fs.readFileSync('$tier_path', 'utf-8')); } catch(e) { entries = []; }
+
+    const entry = entries.find(e => e.id === '$learn_id');
+    if (!entry) {
+      console.error('Entry not found: $learn_id');
+      process.exit(1);
+    }
+
+    entry.archived = true;
+    entry.archived_at = new Date().toISOString();
+
+    fs.writeFileSync(
+      '$archive_dir/manual-$learn_id.json',
+      JSON.stringify([entry], null, 2)
+    );
+    fs.writeFileSync('$tier_path', JSON.stringify(entries, null, 2));
+    console.log('  Archived: $learn_id');
+  " 2>/dev/null || true
+}
+
+# ── learning_promote ──────────────────────────────────────────────────
+# Usage: learning_promote <learn_id> <from_tier_path> <global_path>
+# Copies the entry from from_tier_path into the global tier.
+# Updates the entry's tier field to "global".
+
+learning_promote() {
+  local learn_id="$1"
+  local from_tier_path="$2"
+  local global_path="$3"
+
+  [ ! -f "$from_tier_path" ] && { err "Source tier not found: $from_tier_path"; return 1; }
+
+  _learning_ensure_file "$global_path"
+
+  node -e "
+    const fs = require('fs');
+    let src;
+    try { src = JSON.parse(fs.readFileSync('$from_tier_path', 'utf-8')); } catch(e) { src = []; }
+
+    const entry = src.find(e => e.id === '$learn_id');
+    if (!entry) {
+      console.error('Entry not found: $learn_id');
+      process.exit(1);
+    }
+
+    let global;
+    try { global = JSON.parse(fs.readFileSync('$global_path', 'utf-8')); } catch(e) { global = []; }
+
+    const already = global.find(e => e.id === entry.id);
+    if (already) {
+      console.log('  Already in global tier: $learn_id');
+      process.exit(0);
+    }
+
+    const promoted = Object.assign({}, entry, {
+      tier: 'global',
+      promoted_at: new Date().toISOString(),
+      promotion_candidate: false
+    });
+    global.push(promoted);
+    fs.writeFileSync('$global_path', JSON.stringify(global, null, 2));
+    console.log('  Promoted to global: $learn_id');
+  " 2>/dev/null || true
+}

--- a/scripts/lib/router.sh
+++ b/scripts/lib/router.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# lib/router.sh — Block-based stack routing with specialist fallback (ADR-008 PR-B)
+#
+# Detects the tech stack from file paths associated with a task, maps that stack
+# to the most appropriate specialist agent, checks if the agent is installed, and
+# falls back to the generic feature-marker if not.
+#
+# Stack-map cache: .orchestrator/stack-map.json
+# Agent install check: .claude/agents/<name>.md (or .yaml)
+
+STACK_MAP_FILE="${STACK_MAP_FILE:-$CONFIG_DIR/stack-map.json}"
+AGENTS_DIR="${AGENTS_DIR:-$ROOT_DIR/.claude/agents}"
+
+# ── router_init ──────────────────────────────────────────────────────
+# Usage: router_init <feat_id>
+# Initialises stack-map.json if it does not already exist.
+
+router_init() {
+  local feat_id="$1"
+  mkdir -p "$CONFIG_DIR"
+
+  if [ ! -f "$STACK_MAP_FILE" ]; then
+    node -e "
+      require('fs').writeFileSync('$STACK_MAP_FILE', JSON.stringify({
+        created_at: new Date().toISOString(),
+        entries: {}
+      }, null, 2));
+    " 2>/dev/null || echo '{"created_at":"","entries":{}}' > "$STACK_MAP_FILE"
+  fi
+}
+
+# ── router_detect_stack_from_paths ───────────────────────────────────
+# Usage: router_detect_stack_from_paths <colon:separated:file:paths>
+# Inspects file extensions and returns the detected stack name.
+# Returns: ios | node | python | rust | go | unknown
+
+router_detect_stack_from_paths() {
+  local paths_str="$1"
+
+  # Replace colons with newlines for iteration
+  local stack="unknown"
+  local swift_count=0 node_count=0 python_count=0 rust_count=0 go_count=0
+
+  local IFS_ORIG="$IFS"
+  IFS=":"
+  for path in $paths_str; do
+    IFS="$IFS_ORIG"
+    case "$path" in
+      *.swift)           swift_count=$((swift_count + 1)) ;;
+      *.ts|*.tsx|*.js)   node_count=$((node_count + 1)) ;;
+      *.py)              python_count=$((python_count + 1)) ;;
+      *.rs)              rust_count=$((rust_count + 1)) ;;
+      *.go)              go_count=$((go_count + 1)) ;;
+    esac
+    IFS=":"
+  done
+  IFS="$IFS_ORIG"
+
+  # Pick the most frequent stack; ties broken by declaration order
+  local max=0
+  [ "$swift_count"  -gt "$max" ] && max="$swift_count"  && stack="ios"
+  [ "$node_count"   -gt "$max" ] && max="$node_count"   && stack="node"
+  [ "$python_count" -gt "$max" ] && max="$python_count" && stack="python"
+  [ "$rust_count"   -gt "$max" ] && max="$rust_count"   && stack="rust"
+  [ "$go_count"     -gt "$max" ] && max="$go_count"     && stack="go"
+
+  echo "$stack"
+}
+
+# ── router_stack_to_agent ────────────────────────────────────────────
+# Usage: router_stack_to_agent <stack>
+# Maps a stack name to the preferred specialist agent name.
+
+router_stack_to_agent() {
+  local stack="$1"
+
+  case "$stack" in
+    ios)    echo "swift-expert" ;;
+    node)   echo "typescript-pro" ;;
+    python) echo "python-pro" ;;
+    rust)   echo "rust-expert" ;;
+    go)     echo "go-expert" ;;
+    *)      echo "feature-marker" ;;
+  esac
+}
+
+# ── router_agent_installed ───────────────────────────────────────────
+# Usage: router_agent_installed <agent_name>
+# Returns 0 if an agent definition exists under .claude/agents/; 1 otherwise.
+# Checks for both .md and .yaml/.yml extensions.
+
+router_agent_installed() {
+  local agent_name="$1"
+
+  [ -f "$AGENTS_DIR/${agent_name}.md"   ] && return 0
+  [ -f "$AGENTS_DIR/${agent_name}.yaml" ] && return 0
+  [ -f "$AGENTS_DIR/${agent_name}.yml"  ] && return 0
+  return 1
+}
+
+# ── router_route_task ────────────────────────────────────────────────
+# Usage: router_route_task <feat_id> <task_id> <colon:separated:file:paths>
+# Full routing pipeline:
+#   1. Detect stack from file paths
+#   2. Map stack to preferred agent
+#   3. Check if agent is installed; fall back to feature-marker if not
+#   4. Cache result in stack-map.json
+# Prints the resolved agent name to stdout.
+
+router_route_task() {
+  local feat_id="$1"
+  local task_id="$2"
+  local file_paths="$3"
+
+  router_init "$feat_id"
+
+  # Check cache first
+  local cached
+  cached=$(router_get_cached "$feat_id" "$task_id")
+  if [ -n "$cached" ] && [ "$cached" != "null" ]; then
+    echo "$cached"
+    return 0
+  fi
+
+  # Detect stack
+  local stack
+  stack=$(router_detect_stack_from_paths "$file_paths")
+
+  # Map to agent
+  local preferred_agent
+  preferred_agent=$(router_stack_to_agent "$stack")
+
+  # Fallback if agent not installed
+  local resolved_agent="$preferred_agent"
+  if [ "$preferred_agent" != "feature-marker" ]; then
+    if ! router_agent_installed "$preferred_agent"; then
+      info "Router: $preferred_agent not installed — falling back to feature-marker (task: $task_id)"
+      resolved_agent="feature-marker"
+    fi
+  fi
+
+  # Cache the result
+  node -e "
+    const fs = require('fs');
+    let data;
+    try {
+      data = JSON.parse(fs.readFileSync('$STACK_MAP_FILE', 'utf-8'));
+    } catch(e) {
+      data = { created_at: new Date().toISOString(), entries: {} };
+    }
+    const key = '${feat_id}::${task_id}';
+    data.entries[key] = {
+      feat_id: '$feat_id',
+      task_id: '$task_id',
+      stack: '$stack',
+      preferred_agent: '$preferred_agent',
+      resolved_agent: '$resolved_agent',
+      file_paths: '$file_paths',
+      cached_at: new Date().toISOString()
+    };
+    fs.writeFileSync('$STACK_MAP_FILE', JSON.stringify(data, null, 2));
+  " 2>/dev/null || true
+
+  echo "$resolved_agent"
+}
+
+# ── router_get_cached ────────────────────────────────────────────────
+# Usage: router_get_cached <feat_id> <task_id>
+# Reads the resolved agent from stack-map.json cache.
+# Prints the agent name, or empty string if not cached.
+
+router_get_cached() {
+  local feat_id="$1"
+  local task_id="$2"
+
+  [ ! -f "$STACK_MAP_FILE" ] && echo "" && return
+
+  node -p "
+    try {
+      const data = JSON.parse(require('fs').readFileSync('$STACK_MAP_FILE', 'utf-8'));
+      const key = '${feat_id}::${task_id}';
+      const entry = data.entries && data.entries[key];
+      entry ? entry.resolved_agent : '';
+    } catch(e) { ''; }
+  " 2>/dev/null || echo ""
+}

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -3,6 +3,15 @@
 #
 # Handles backlog iteration, dependency checking, agent routing,
 # Claude CLI invocation, PR creation, retry, and state tracking.
+#
+# ADR-008 additions:
+#   - Phase 0 optimisation: skip Claude when artifacts already exist
+#   - run_phase3_tests(): scripted test runner with max 2 fix attempts
+#   - dep_check_merge_state(): hard-block dependency polling via git platform CLI
+#   - cost_record() calls at each phase boundary (cost.sh)
+#   - learning_read() / learning_write() for Phase 3 fix hints (learning.sh)
+#   - router_route_task() for stack-aware agent selection (router.sh)
+#   - cycle_gate_check() before advancing to next feature (cycle_gate.sh)
 
 run_backlog() {
   local backlog_file="$1"
@@ -82,14 +91,38 @@ run_backlog() {
     info "Single-feature mode: $OPT_FEATURE"
     process_item "$single" 1 1
   else
-    # Main loop
+    # Main loop — ADR-008: check hard-block deps + cycle gate per item
     local index=0
     echo "$items" | node -e "
       const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
       d.ready.forEach(i => console.log(JSON.stringify(i)));
     " | while IFS= read -r item_json; do
       index=$((index + 1))
+
+      # ADR-008 PR-C: hard-block dependency check
+      local feat_id_check
+      feat_id_check=$(echo "$item_json" | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8')).id")
+      local deps_check
+      deps_check=$(echo "$item_json" | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8')).dependencies.join(',')||''")
+
+      if [ -n "$deps_check" ]; then
+        if ! dep_check_merge_state "$feat_id_check" "$deps_check"; then
+          info "Skipping $feat_id_check — unmerged dependencies (hard-block)"
+          continue
+        fi
+      fi
+
       process_item "$item_json" "$index" "$ready_count"
+
+      # ADR-008 PR-D: cycle gate — assert previous feature completed full cycle
+      if [ "${OPT_SKIP_CYCLE_CHECK:-false}" != "true" ]; then
+        if ! cycle_gate_check "$feat_id_check"; then
+          info "Cycle gate: $feat_id_check did not complete full cycle"
+          cycle_gate_report "$feat_id_check"
+          info "Use --skip-cycle-check to bypass. Stopping backlog loop."
+          break
+        fi
+      fi
     done
   fi
 
@@ -170,6 +203,9 @@ run_feature() {
   # Mark as in progress
   wt_update_status "$feat_id" "in-progress" "analysis" 2>/dev/null || true
 
+  # ADR-008 PR-A: initialise cost accumulator
+  cost_init "$feat_id"
+
   # Create worktree (handles stale worktrees from crashed runs)
   info "Creating worktree..."
   local wt_path
@@ -194,13 +230,54 @@ $body
 EOPRD
   info "Seeded PRD"
 
+  # ── ADR-008 PR-A: Phase 0 optimisation ──────────────────────────
+  # If all three artifacts already exist, skip Claude invocation for Phase 0.
+  local phase0_cost=0
+  if [ -f "$task_dir/prd.md" ] && [ -f "$task_dir/techspec.md" ] && [ -f "$task_dir/tasks.md" ]; then
+    info "Phase 0: artifacts exist, skipping generation (cost: 0)"
+  else
+    info "Phase 0: artifacts missing — Claude will generate them (cost: $COST_PHASE_1_PLANNING)"
+    phase0_cost="$COST_PHASE_1_PLANNING"
+  fi
+  cost_record "$feat_id" "phase0" "$phase0_cost"
+
+  # ── ADR-008 PR-D: feature-sizing gate ───────────────────────────
+  # Only run if tasks.md exists (post-generation check on subsequent runs)
+  if [ -f "$task_dir/tasks.md" ]; then
+    if ! size_gate_check "$feat_id" "$wt_path"; then
+      local exceeded_str="${SIZE_EXCEEDED_CRITERIA:+$SIZE_EXCEEDED_CRITERIA }${SIZE_EXCEEDED_TASKS:+$SIZE_EXCEEDED_TASKS }${SIZE_EXCEEDED_FILES:+$SIZE_EXCEEDED_FILES}"
+      if ! size_gate_signal "$feat_id" "$AUTONOMY" "$exceeded_str"; then
+        wt_update_status "$feat_id" "paused" "size-gate"
+        return 0
+      fi
+    fi
+  fi
+
   # Build context (memory layer 1 + error patterns)
   local context_file
   context_file=$(mem_build_context "$feat_id" "$title" "$priority" "$labels" "$deps" "$body" "$wt_path")
   cp "$context_file" "$wt_path/.orchestrator-context.md"
   info "Context injected"
 
-  # Route tasks to agents (ADR-006)
+  # ── ADR-008 PR-B: stack detection + agent routing ────────────────
+  router_init "$feat_id"
+
+  # Detect stack from worktree file structure
+  local wt_file_paths
+  wt_file_paths=$(find "$wt_path" -type f \( -name "*.swift" -o -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.py" -o -name "*.rs" -o -name "*.go" \) 2>/dev/null | head -20 | tr '\n' ':')
+
+  local detected_stack="unknown"
+  local routed_agent="${ROUTING_FALLBACK:-feature-marker}"
+
+  if [ -n "$wt_file_paths" ]; then
+    detected_stack=$(router_detect_stack_from_paths "$wt_file_paths")
+    routed_agent=$(router_route_task "$feat_id" "feature" "$wt_file_paths")
+    info "Stack: $detected_stack → agent: $routed_agent"
+  fi
+
+  export ROUTED_AGENT="$routed_agent"
+
+  # Route tasks via ADR-006 manifest (existing behaviour preserved)
   local routing_file="$STATE_DIR/$feat_id/routing.json"
   local manifest_file="$CONFIG_DIR/agents-manifest.json"
   local agent_count=0
@@ -232,14 +309,31 @@ EOPRD
   local feat_start
   feat_start=$(date +%s)
 
+  # ADR-008 PR-A: Phase 1 cost record
+  cost_record "$feat_id" "phase1" "$COST_PHASE_1_PLANNING"
+
+  # Determine task count and agent type for Phase 2 cost
+  local task_count=1
+  if [ -f "$task_dir/tasks.md" ]; then
+    task_count=$(grep -c "^\- \[" "$task_dir/tasks.md" 2>/dev/null || echo "1")
+    [ "$task_count" -eq 0 ] && task_count=1
+  fi
+  local agent_type="generic"
+  [ "$routed_agent" != "feature-marker" ] && agent_type="specialist"
+  local phase2_cost
+  phase2_cost=$(cost_estimate_phase "2" "$task_count" "$agent_type")
+  cost_record "$feat_id" "phase2" "$phase2_cost"
+
   # Invoke feature-marker via Claude Code
   local model_flag=""
   [ -n "${MODEL_DEFAULT:-}" ] && model_flag="--model $MODEL_DEFAULT"
 
   if [ "$AUTONOMY" = "full_auto" ]; then
-    info "Autonomy=full_auto — invoking pipeline (model: ${MODEL_DEFAULT:-default})..."
+    info "Autonomy=full_auto — invoking pipeline (model: ${MODEL_DEFAULT:-default}, agent: $routed_agent)..."
     if command -v claude &>/dev/null; then
-      (cd "$wt_path" && claude $model_flag --skill feature-marker "prd-$feat_id") 2>&1 | tee "$log_file" || exit_code=$?
+      local skill_arg="feature-marker"
+      [ "$routed_agent" != "feature-marker" ] && skill_arg="$routed_agent"
+      (cd "$wt_path" && claude $model_flag --skill "$skill_arg" "prd-$feat_id") 2>&1 | tee "$log_file" || exit_code=$?
     else
       info "Claude CLI not found — simulating pipeline"
       echo "full_auto: simulated pipeline for $feat_id (model: ${MODEL_DEFAULT:-default})" > "$log_file"
@@ -251,6 +345,21 @@ EOPRD
     info "Autonomy=supervised — paused for review"
     echo "supervised: paused for $feat_id" > "$log_file"
   fi
+
+  # ── ADR-008 PR-A: Phase 3 scripted tests ────────────────────────
+  if [ "$AUTONOMY" = "full_auto" ] && [ "$exit_code" -eq 0 ]; then
+    local phase3_fix_attempts=0
+    run_phase3_tests "$feat_id" "$wt_path"
+    local phase3_exit=$?
+    phase3_fix_attempts=$(cat "$STATE_DIR/$feat_id/phase3-fix-attempts" 2>/dev/null || echo "0")
+    local phase3_cost
+    phase3_cost=$(cost_estimate_phase "3" "$phase3_fix_attempts" "generic")
+    cost_record "$feat_id" "phase3" "$phase3_cost"
+    [ "$phase3_exit" -ne 0 ] && exit_code="$phase3_exit"
+  fi
+
+  # ADR-008 PR-A: Phase 4 cost record
+  cost_record "$feat_id" "phase4" "$COST_PHASE_4_COMMIT_PR"
 
   local feat_end
   feat_end=$(date +%s)
@@ -266,7 +375,7 @@ EOPRD
         title: $(printf '%s' "$title" | node -p "JSON.stringify(require('fs').readFileSync('/dev/stdin','utf-8').trim())"),
         pipeline: { prd: { status: 'completed' }, techspec: { status: 'pending' }, tasks: { status: 'pending' }, implementation: { status: 'pending' }, tests: { status: 'pending' }, review: { status: 'pending' } },
         context_generated: { files_created: [], files_modified: [], schema_changes: [], new_dependencies: [], breaking_changes: [] },
-        pr_url: null, duration_seconds: $duration, errors: []
+        pr_url: null, duration_seconds: $duration, errors: [], tasks: []
       }, null, 2));
     "
   fi
@@ -319,12 +428,260 @@ EOPRD
     fi
   fi
 
+  # ADR-008 PR-A: print cost summary
+  cost_summary "$feat_id"
+
   # Feedback: context + env refresh
   mem_record_context "$feat_id" "$title" "$priority" "$labels" "$wt_path" "$results_file"
   mem_refresh_env
 
   info "Feature time: ${duration}s"
   echo ""
+}
+
+# ── run_phase3_tests ──────────────────────────────────────────────────
+# ADR-008 PR-A: Scripted test runner for Phase 3.
+# Detects stack, runs the appropriate test command.
+# On failure, invokes Claude for a fix (max 2 attempts).
+# Captures successful fixes to the learning store.
+# Writes fix attempt count to $STATE_DIR/$feat_id/phase3-fix-attempts.
+# Returns 0 on success (tests pass), 1 on persistent failure.
+
+run_phase3_tests() {
+  local feat_id="$1"
+  local wt_path="$2"
+
+  local fix_attempts=0
+  echo "$fix_attempts" > "$STATE_DIR/$feat_id/phase3-fix-attempts"
+
+  # Detect stack from worktree
+  local wt_file_paths
+  wt_file_paths=$(find "$wt_path" -type f \( -name "*.swift" -o -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.py" -o -name "*.rs" -o -name "*.go" \) 2>/dev/null | head -20 | tr '\n' ':')
+  local stack="unknown"
+  [ -n "$wt_file_paths" ] && stack=$(router_detect_stack_from_paths "$wt_file_paths")
+
+  # Map stack to test command
+  local test_cmd=""
+  case "$stack" in
+    ios)    test_cmd="swift test" ;;
+    node)   test_cmd="jest" ;;
+    rust)   test_cmd="cargo test" ;;
+    python) test_cmd="pytest" ;;
+    go)     test_cmd="go test ./..." ;;
+    *)
+      info "Phase 3: unknown stack — skipping scripted tests"
+      return 0
+      ;;
+  esac
+
+  info "Phase 3: running tests ($stack): $test_cmd"
+
+  local test_output
+  local test_exit=0
+
+  (cd "$wt_path" && eval "$test_cmd" >/tmp/phase3-test-output-$$.txt 2>&1) || test_exit=$?
+
+  if [ "$test_exit" -eq 0 ]; then
+    info "Phase 3: tests passed"
+    return 0
+  fi
+
+  test_output=$(cat /tmp/phase3-test-output-$$.txt 2>/dev/null || echo "test output unavailable")
+  rm -f /tmp/phase3-test-output-$$.txt
+
+  # Fix loop — max 2 attempts
+  local max_fix_attempts=2
+
+  while [ "$fix_attempts" -lt "$max_fix_attempts" ]; do
+    fix_attempts=$((fix_attempts + 1))
+    echo "$fix_attempts" > "$STATE_DIR/$feat_id/phase3-fix-attempts"
+
+    info "Phase 3: fix attempt $fix_attempts/$max_fix_attempts"
+
+    # ADR-008 PR-C: check learning store for a known fix
+    local error_sig
+    error_sig=$(echo "$test_output" | head -5 | tr '\n' ' ' | sed 's/  */ /g')
+    local learned_fix
+    learned_fix=$(learning_read "$feat_id" "$error_sig")
+
+    local fix_prompt="Fix the failing tests. Test output:\n$test_output"
+    if [ -n "$learned_fix" ] && [ "$learned_fix" != "null" ]; then
+      local hint
+      hint=$(echo "$learned_fix" | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8')).fix" 2>/dev/null || echo "")
+      if [ -n "$hint" ]; then
+        info "Phase 3: applying learned fix hint"
+        fix_prompt="$fix_prompt\n\nKnown fix hint: $hint"
+      fi
+    fi
+
+    local model_flag=""
+    [ -n "${MODEL_DEFAULT:-}" ] && model_flag="--model $MODEL_DEFAULT"
+
+    local fix_exit=0
+    if command -v claude &>/dev/null; then
+      (cd "$wt_path" && printf '%b' "$fix_prompt" | claude $model_flag --print) 2>/dev/null || fix_exit=$?
+    else
+      info "Phase 3: Claude CLI not found — cannot attempt fix"
+      return 1
+    fi
+
+    # Re-run tests
+    test_exit=0
+    (cd "$wt_path" && eval "$test_cmd" >/tmp/phase3-test-output-$$.txt 2>&1) || test_exit=$?
+
+    if [ "$test_exit" -eq 0 ]; then
+      info "Phase 3: tests passed after fix attempt $fix_attempts"
+
+      # ADR-008 PR-C: capture successful fix to learning store
+      local fix_description
+      fix_description=$(printf '%b' "$fix_prompt" | head -3 | tr '\n' ' ')
+      learning_write "$feat_id" "$error_sig" "$fix_description"
+
+      # Verify the learning entry
+      local project_path
+      project_path="$ROOT_DIR/.claude/feature-state/learned.json"
+      if [ -f "$project_path" ]; then
+        local learn_id
+        learn_id=$(node -p "
+          try {
+            const entries = JSON.parse(require('fs').readFileSync('$project_path','utf-8'));
+            const match = entries.find(e => !e.archived && e.pattern === $(node -p "JSON.stringify('$error_sig')" 2>/dev/null || echo "''"));
+            match ? match.id : '';
+          } catch(e) { ''; }
+        " 2>/dev/null || echo "")
+        [ -n "$learn_id" ] && learning_verify "$learn_id" "true" "$project_path"
+      fi
+
+      rm -f /tmp/phase3-test-output-$$.txt
+      return 0
+    fi
+
+    test_output=$(cat /tmp/phase3-test-output-$$.txt 2>/dev/null || echo "test output unavailable")
+    rm -f /tmp/phase3-test-output-$$.txt
+    mem_record_error "$feat_id" "phase3" "fix attempt $fix_attempts failed: $test_cmd"
+  done
+
+  err "Phase 3: tests still failing after $max_fix_attempts fix attempts"
+  return 1
+}
+
+# ── dep_check_merge_state ─────────────────────────────────────────────
+# ADR-008 PR-C: Hard-block dependency check.
+# For each dependency ID, looks up the parent PR number from its results.json,
+# then queries the git platform CLI to confirm the PR is merged.
+# Returns 0 if all deps are merged (or have no PR data); 1 if any dep is unmerged.
+
+dep_check_merge_state() {
+  local feat_id="$1"
+  local deps_csv="$2"  # comma-separated list of dependency feature IDs
+
+  [ -z "$deps_csv" ] && return 0
+
+  # Determine platform (uses ADAPTER already loaded by config.sh)
+  local platform="github"
+  case "${ADAPTER:-markdown}" in
+    github)   platform="github" ;;
+    linear)   platform="github" ;;  # assume GitHub for PR checks
+    *)        platform="github" ;;
+  esac
+
+  # Check if az or glab CLI present to override platform detection
+  if command -v glab &>/dev/null; then
+    platform="gitlab"
+  elif command -v az &>/dev/null; then
+    platform="azure"
+  fi
+
+  local all_merged=0
+  local IFS_ORIG="$IFS"
+  IFS=","
+  for dep_id in $deps_csv; do
+    IFS="$IFS_ORIG"
+    dep_id=$(echo "$dep_id" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+    [ -z "$dep_id" ] && continue
+
+    local dep_results="$STATE_DIR/$dep_id/results.json"
+    if [ ! -f "$dep_results" ]; then
+      info "Dep $dep_id: no results.json — assuming not yet run (allowing)"
+      IFS=","
+      continue
+    fi
+
+    local pr_url
+    pr_url=$(node -p "
+      try {
+        const r = JSON.parse(require('fs').readFileSync('$dep_results','utf-8'));
+        r.pr_url || '';
+      } catch(e) { ''; }
+    " 2>/dev/null || echo "")
+
+    if [ -z "$pr_url" ]; then
+      info "Dep $dep_id: no PR URL recorded — assuming not complete (blocking)"
+      all_merged=1
+      IFS=","
+      continue
+    fi
+
+    # Extract PR number from URL
+    local pr_num
+    pr_num=$(echo "$pr_url" | sed 's|.*/||')
+
+    local is_merged=false
+    case "$platform" in
+      github)
+        if command -v gh &>/dev/null; then
+          local gh_state
+          gh_state=$(gh pr view "$pr_num" --json state,mergedAt 2>/dev/null || echo '{}')
+          is_merged=$(echo "$gh_state" | node -p "
+            try {
+              const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+              (d.state === 'MERGED' || (d.mergedAt && d.mergedAt.length > 0)) ? 'true' : 'false';
+            } catch(e) { 'false'; }
+          " 2>/dev/null || echo "false")
+        else
+          info "Dep $dep_id: gh CLI not available — assuming merged (allowing)"
+          is_merged="true"
+        fi
+        ;;
+      azure)
+        if command -v az &>/dev/null; then
+          local az_state
+          az_state=$(az repos pr show --id "$pr_num" 2>/dev/null || echo '{}')
+          is_merged=$(echo "$az_state" | node -p "
+            try {
+              const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+              d.status === 'completed' ? 'true' : 'false';
+            } catch(e) { 'false'; }
+          " 2>/dev/null || echo "false")
+        else
+          info "Dep $dep_id: az CLI not available — assuming merged (allowing)"
+          is_merged="true"
+        fi
+        ;;
+      gitlab)
+        if command -v glab &>/dev/null; then
+          local glab_out
+          glab_out=$(glab mr view "$pr_num" 2>/dev/null || echo "state: open")
+          echo "$glab_out" | grep -qi "merged" && is_merged="true" || is_merged="false"
+        else
+          info "Dep $dep_id: glab CLI not available — assuming merged (allowing)"
+          is_merged="true"
+        fi
+        ;;
+    esac
+
+    if [ "$is_merged" != "true" ]; then
+      info "Dep $dep_id: PR #$pr_num not yet merged (state: unmerged)"
+      all_merged=1
+    else
+      info "Dep $dep_id: PR #$pr_num merged — OK"
+    fi
+
+    IFS=","
+  done
+  IFS="$IFS_ORIG"
+
+  return $all_merged
 }
 
 run_pr_creation() {

--- a/scripts/lib/size_gate.sh
+++ b/scripts/lib/size_gate.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# lib/size_gate.sh — Feature-sizing gate (ADR-008 PR-D)
+#
+# Reads metrics from PRD/techspec/tasks files in the worktree and compares
+# them against configured thresholds. In supervised mode the user is prompted;
+# in checkpoint/full_auto mode a split-signal file is written.
+#
+# Exported variables (populated by size_gate_load_config):
+#   SIZE_MAX_CRITERIA    — max acceptance criteria lines in prd.md
+#   SIZE_MAX_TASKS       — max task lines in tasks.md
+#   SIZE_MAX_FILE_CHANGES — max file paths in techspec.md "Files to Modify"
+
+# ── Load thresholds from CFG_* (set by config.sh / parse-config.js) ──
+
+size_gate_load_config() {
+  SIZE_MAX_CRITERIA="${CFG_SAFETY_FEATURE_SIZE_MAX_ACCEPTANCE_CRITERIA:-15}"
+  SIZE_MAX_TASKS="${CFG_SAFETY_FEATURE_SIZE_MAX_TASKS:-20}"
+  SIZE_MAX_FILE_CHANGES="${CFG_SAFETY_FEATURE_SIZE_MAX_FILE_CHANGES_ESTIMATE:-80}"
+
+  export SIZE_MAX_CRITERIA SIZE_MAX_TASKS SIZE_MAX_FILE_CHANGES
+}
+
+# Ensure thresholds are available when the module is sourced
+size_gate_load_config
+
+# ── _count_acceptance_criteria ───────────────────────────────────────
+# Counts bullet/numbered lines in the acceptance section of prd.md.
+
+_count_acceptance_criteria() {
+  local prd_file="$1"
+  [ ! -f "$prd_file" ] && echo "0" && return
+
+  node -e "
+    const fs = require('fs');
+    const text = fs.readFileSync('$prd_file', 'utf-8');
+    // Find acceptance criteria section (case-insensitive heading)
+    const match = text.match(/##[^\\n]*acceptance[^\\n]*/i);
+    if (!match) {
+      // Fall back: count all bullet/numbered lines
+      const lines = text.split('\\n').filter(l => /^-\\s/.test(l) || /^\\d+\\.\\s/.test(l));
+      console.log(lines.length);
+      return;
+    }
+    const start = text.indexOf(match[0]) + match[0].length;
+    // Section ends at next ## heading or EOF
+    const rest = text.slice(start);
+    const nextSection = rest.search(/\\n##\\s/);
+    const section = nextSection >= 0 ? rest.slice(0, nextSection) : rest;
+    const lines = section.split('\\n').filter(l => /^-\\s/.test(l) || /^\\d+\\.\\s/.test(l));
+    console.log(lines.length);
+  " 2>/dev/null || echo "0"
+}
+
+# ── _count_tasks ──────────────────────────────────────────────────────
+# Counts task lines (checkboxes or headings) in tasks.md.
+
+_count_tasks() {
+  local tasks_file="$1"
+  [ ! -f "$tasks_file" ] && echo "0" && return
+
+  node -e "
+    const fs = require('fs');
+    const lines = fs.readFileSync('$tasks_file', 'utf-8').split('\\n');
+    // Count checkbox lines: - [ ] or - [x]
+    const checkboxes = lines.filter(l => /^-\\s+\\[/.test(l)).length;
+    // Count ### headings as task groups if no checkboxes found
+    const headings = lines.filter(l => /^###\\s/.test(l)).length;
+    console.log(checkboxes > 0 ? checkboxes : headings);
+  " 2>/dev/null || echo "0"
+}
+
+# ── _count_file_changes ───────────────────────────────────────────────
+# Counts file paths listed under a "Files to Modify" section in techspec.md.
+
+_count_file_changes() {
+  local techspec_file="$1"
+  [ ! -f "$techspec_file" ] && echo "0" && return
+
+  node -e "
+    const fs = require('fs');
+    const text = fs.readFileSync('$techspec_file', 'utf-8');
+    const match = text.match(/##[^\\n]*(files to modify|files changed|modified files)[^\\n]*/i);
+    if (!match) { console.log(0); return; }
+    const start = text.indexOf(match[0]) + match[0].length;
+    const rest = text.slice(start);
+    const nextSection = rest.search(/\\n##\\s/);
+    const section = nextSection >= 0 ? rest.slice(0, nextSection) : rest;
+    // Count bullet lines containing a path-like string (contains / or .)
+    const lines = section.split('\\n').filter(l => /^-\\s/.test(l) && /[\\/.]/.test(l));
+    console.log(lines.length);
+  " 2>/dev/null || echo "0"
+}
+
+# ── size_gate_check ───────────────────────────────────────────────────
+# Usage: size_gate_check <feat_id> <wt_path>
+# Reads metrics and compares to thresholds.
+# Returns 0 if within bounds; 1 if any threshold is exceeded.
+# Populates SIZE_EXCEEDED_CRITERIA, SIZE_EXCEEDED_TASKS, SIZE_EXCEEDED_FILES
+# shell variables with actual vs max strings for diagnostics.
+
+size_gate_check() {
+  local feat_id="$1"
+  local wt_path="$2"
+
+  local task_dir="$wt_path/tasks/prd-$feat_id"
+  local prd_file="$task_dir/prd.md"
+  local techspec_file="$task_dir/techspec.md"
+  local tasks_file="$task_dir/tasks.md"
+
+  local criteria_count
+  local task_count
+  local file_count
+
+  criteria_count=$(_count_acceptance_criteria "$prd_file")
+  task_count=$(_count_tasks "$tasks_file")
+  file_count=$(_count_file_changes "$techspec_file")
+
+  SIZE_EXCEEDED_CRITERIA=""
+  SIZE_EXCEEDED_TASKS=""
+  SIZE_EXCEEDED_FILES=""
+
+  local exceeded=0
+
+  if [ "$criteria_count" -gt "$SIZE_MAX_CRITERIA" ]; then
+    SIZE_EXCEEDED_CRITERIA="acceptance_criteria=${criteria_count}/${SIZE_MAX_CRITERIA}"
+    exceeded=1
+  fi
+
+  if [ "$task_count" -gt "$SIZE_MAX_TASKS" ]; then
+    SIZE_EXCEEDED_TASKS="tasks=${task_count}/${SIZE_MAX_TASKS}"
+    exceeded=1
+  fi
+
+  if [ "$file_count" -gt "$SIZE_MAX_FILE_CHANGES" ]; then
+    SIZE_EXCEEDED_FILES="file_changes=${file_count}/${SIZE_MAX_FILE_CHANGES}"
+    exceeded=1
+  fi
+
+  export SIZE_EXCEEDED_CRITERIA SIZE_EXCEEDED_TASKS SIZE_EXCEEDED_FILES
+
+  return $exceeded
+}
+
+# ── size_gate_signal ──────────────────────────────────────────────────
+# Usage: size_gate_signal <feat_id> <autonomy> <exceeded_metrics>
+# Handles the policy response to an oversized feature.
+#   supervised    : warns and prompts the user interactively
+#   checkpoint    : logs split signal to state/{feat_id}/size-exceeded.json
+#   full_auto     : logs split signal (same as checkpoint)
+
+size_gate_signal() {
+  local feat_id="$1"
+  local autonomy="$2"
+  local exceeded_metrics="$3"
+
+  local signal_file="$STATE_DIR/$feat_id/size-exceeded.json"
+  mkdir -p "$STATE_DIR/$feat_id"
+
+  case "$autonomy" in
+    supervised)
+      echo ""
+      info "! Feature $feat_id exceeds size thresholds: $exceeded_metrics"
+      info "  Consider splitting into smaller features before proceeding."
+      echo ""
+      # Read from /dev/tty to avoid consuming stdin from the calling pipeline
+      local answer="n"
+      if [ -t 0 ]; then
+        read -r -p "  Proceed anyway? [y/N] " answer </dev/tty || answer="n"
+      else
+        info "  (non-interactive mode — defaulting to skip)"
+      fi
+      case "$answer" in
+        y|Y|yes|YES)
+          info "Proceeding despite size warning for $feat_id"
+          return 0
+          ;;
+        *)
+          info "Skipping $feat_id due to size gate. Split the feature and re-run."
+          node -e "
+            require('fs').writeFileSync('$signal_file', JSON.stringify({
+              feature_id: '$feat_id',
+              recorded_at: new Date().toISOString(),
+              exceeded: '$exceeded_metrics',
+              action: 'user_skipped'
+            }, null, 2));
+          " 2>/dev/null || true
+          return 1
+          ;;
+      esac
+      ;;
+
+    checkpoint|full_auto)
+      info "! Feature $feat_id exceeds size thresholds: $exceeded_metrics"
+      info "  Writing split signal to: $signal_file"
+      node -e "
+        require('fs').writeFileSync('$signal_file', JSON.stringify({
+          feature_id: '$feat_id',
+          recorded_at: new Date().toISOString(),
+          exceeded: '$exceeded_metrics',
+          action: 'auto_split_signal',
+          note: 'Feature should be split before next run'
+        }, null, 2));
+      " 2>/dev/null || true
+      return 1
+      ;;
+
+    *)
+      info "! Size gate exceeded for $feat_id ($exceeded_metrics) — no action for autonomy=$autonomy"
+      return 0
+      ;;
+  esac
+}

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -77,10 +77,15 @@ OPT_CONFIG="orchestrator/config.yml"
 OPT_DRY_RUN=false
 OPT_FEATURE=""
 OPT_RESUME=false
+OPT_SKIP_CYCLE_CHECK=false
+OPT_SAMPLE=10
+OPT_LEARNING_ACTION=""
+OPT_LEARNING_ID=""
+OPT_LEARNING_CANDIDATES=false
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    init|run|status|clean)
+    init|run|status|clean|calibrate|learning|promote-learning)
       SUBCOMMAND="$1"
       ;;
     --autonomy)
@@ -104,34 +109,66 @@ while [ $# -gt 0 ]; do
     --resume)
       OPT_RESUME=true
       ;;
+    --skip-cycle-check)
+      OPT_SKIP_CYCLE_CHECK=true
+      ;;
+    --sample)
+      shift; OPT_SAMPLE="$1"
+      ;;
+    --candidates)
+      OPT_LEARNING_CANDIDATES=true
+      ;;
+    list|archive|promote)
+      # Sub-subcommands for the learning subcommand
+      [ "$SUBCOMMAND" = "learning" ] && OPT_LEARNING_ACTION="$1"
+      ;;
     --help|-h)
       echo "Usage: orchestrate.sh <command> [flags]"
       echo ""
       echo "Commands:"
-      echo "  init                 Scaffold config, .env, features.md, .gitignore"
-      echo "  run                  Execute the orchestration loop"
-      echo "  status               Show current orchestrator state"
-      echo "  clean                Remove all worktrees and reset state"
+      echo "  init                       Scaffold config, .env, features.md, .gitignore"
+      echo "  run                        Execute the orchestration loop"
+      echo "  status                     Show current orchestrator state"
+      echo "  clean                      Remove all worktrees and reset state"
+      echo "  calibrate                  Show token-cost calibration guidance"
+      echo "  learning list              List all learning entries"
+      echo "  learning list --candidates List only promotion candidates"
+      echo "  learning archive <id>      Archive a learning entry by ID"
+      echo "  learning promote <id>      Promote a project entry to global tier"
+      echo "  promote-learning <id>      Alias for: learning promote <id>"
       echo ""
       echo "Flags:"
-      echo "  --autonomy <level>   supervised | checkpoint | full_auto"
-      echo "  --adapter <type>     markdown | github | linear"
-      echo "  --model <name>       opus | sonnet | haiku | opusplan"
-      echo "  --config <path>      Config file (default: orchestrator/config.yml)"
-      echo "  --feature <id>       Run only the specified feature"
-      echo "  --plan, --dry-run    Show plan without executing"
-      echo "  --resume             Skip completed, run pending"
-      echo "  --help               Show this help"
+      echo "  --autonomy <level>         supervised | checkpoint | full_auto"
+      echo "  --adapter <type>           markdown | github | linear"
+      echo "  --model <name>             opus | sonnet | haiku | opusplan"
+      echo "  --config <path>            Config file (default: orchestrator/config.yml)"
+      echo "  --feature <id>             Run only the specified feature"
+      echo "  --plan, --dry-run          Show plan without executing"
+      echo "  --resume                   Skip completed, run pending"
+      echo "  --skip-cycle-check         Skip the cycle-completion gate"
+      echo "  --sample <n>               Sample size for calibrate (default: 10)"
+      echo "  --help                     Show this help"
       exit 0
       ;;
     *)
-      err "Unknown argument: $1"
-      err "Run: ./scripts/orchestrate.sh --help"
-      exit 1
+      # Capture positional arguments for subcommands that need them (e.g. learning archive <id>)
+      if [ "$SUBCOMMAND" = "learning" ] && [ -z "$OPT_LEARNING_ACTION" ]; then
+        OPT_LEARNING_ACTION="$1"
+      elif [ "$SUBCOMMAND" = "learning" ] && [ -z "$OPT_LEARNING_ID" ]; then
+        OPT_LEARNING_ID="$1"
+      elif [ "$SUBCOMMAND" = "promote-learning" ] && [ -z "$OPT_LEARNING_ID" ]; then
+        OPT_LEARNING_ID="$1"
+      else
+        err "Unknown argument: $1"
+        err "Run: ./scripts/orchestrate.sh --help"
+        exit 1
+      fi
       ;;
   esac
   shift
 done
+
+export OPT_SKIP_CYCLE_CHECK
 
 [ -z "$SUBCOMMAND" ] && { err "No command given. Run: ./scripts/orchestrate.sh --help"; exit 1; }
 
@@ -264,6 +301,12 @@ sub_run() {
   source "$LIB_DIR/worktree.sh"
   source "$LIB_DIR/memory.sh"
   source "$LIB_DIR/display.sh"
+  # ADR-008 modules
+  source "$LIB_DIR/cost.sh"
+  source "$LIB_DIR/router.sh"
+  source "$LIB_DIR/learning.sh"
+  source "$LIB_DIR/size_gate.sh"
+  source "$LIB_DIR/cycle_gate.sh"
   source "$LIB_DIR/runner.sh"
 
   # Resolve config file — check multiple locations
@@ -397,12 +440,98 @@ sub_clean() {
 }
 
 # ══════════════════════════════════════════════════════════════════
+# Subcommand: calibrate (ADR-008 PR-A)
+# ══════════════════════════════════════════════════════════════════
+
+sub_calibrate() {
+  source "$LIB_DIR/config.sh"
+  source "$LIB_DIR/cost.sh"
+
+  local config_file="$OPT_CONFIG"
+  if [ ! -f "$config_file" ]; then
+    [ -f ".orchestrator/config.yaml" ] && config_file=".orchestrator/config.yaml"
+    [ -f ".orchestrator/config.yml"  ] && config_file=".orchestrator/config.yml"
+    [ -f "orchestrator/config.yml"   ] && config_file="orchestrator/config.yml"
+  fi
+
+  load_config "$config_file" 2>/dev/null || true
+  cost_load_config
+
+  banner "Token Cost Calibration"
+  cost_calibrate "$OPT_SAMPLE"
+}
+
+# ══════════════════════════════════════════════════════════════════
+# Subcommand: learning (ADR-008 PR-C)
+# ══════════════════════════════════════════════════════════════════
+
+sub_learning() {
+  source "$LIB_DIR/config.sh"
+  source "$LIB_DIR/learning.sh"
+
+  local config_file="$OPT_CONFIG"
+  if [ ! -f "$config_file" ]; then
+    [ -f ".orchestrator/config.yaml" ] && config_file=".orchestrator/config.yaml"
+    [ -f ".orchestrator/config.yml"  ] && config_file=".orchestrator/config.yml"
+    [ -f "orchestrator/config.yml"   ] && config_file="orchestrator/config.yml"
+  fi
+  load_config "$config_file" 2>/dev/null || true
+
+  local project_path="$ROOT_DIR/.claude/feature-state/learned.json"
+  local global_path="$HOME/.claude/feature-marker/learned/learned.json"
+
+  case "${OPT_LEARNING_ACTION:-list}" in
+    list)
+      banner "Learning Entries (project tier)"
+      learning_list "$project_path" "$OPT_LEARNING_CANDIDATES"
+      ;;
+    archive)
+      if [ -z "$OPT_LEARNING_ID" ]; then
+        err "Usage: learning archive <id>"
+        exit 1
+      fi
+      banner "Archive Learning Entry"
+      learning_archive "$OPT_LEARNING_ID" "$project_path"
+      ;;
+    promote)
+      if [ -z "$OPT_LEARNING_ID" ]; then
+        err "Usage: learning promote <id>"
+        exit 1
+      fi
+      banner "Promote Learning Entry to Global"
+      learning_promote "$OPT_LEARNING_ID" "$project_path" "$global_path"
+      ;;
+    *)
+      err "Unknown learning action: $OPT_LEARNING_ACTION"
+      err "Available: list, archive <id>, promote <id>"
+      exit 1
+      ;;
+  esac
+}
+
+# ══════════════════════════════════════════════════════════════════
+# Subcommand: promote-learning (alias for learning promote)
+# ══════════════════════════════════════════════════════════════════
+
+sub_promote_learning() {
+  if [ -z "$OPT_LEARNING_ID" ]; then
+    err "Usage: promote-learning <id>"
+    exit 1
+  fi
+  OPT_LEARNING_ACTION="promote"
+  sub_learning
+}
+
+# ══════════════════════════════════════════════════════════════════
 # Dispatch
 # ══════════════════════════════════════════════════════════════════
 
 case "$SUBCOMMAND" in
-  init)   sub_init ;;
-  run)    sub_run ;;
-  status) sub_status ;;
-  clean)  sub_clean ;;
+  init)            sub_init ;;
+  run)             sub_run ;;
+  status)          sub_status ;;
+  clean)           sub_clean ;;
+  calibrate)       sub_calibrate ;;
+  learning)        sub_learning ;;
+  promote-learning) sub_promote_learning ;;
 esac


### PR DESCRIPTION
## Summary

- **PR-A** — Phase 0 skips Claude when PRD artifacts already exist; Phase 3 runs stack-native tests before invoking Claude (max 2 fix attempts); `scripts/lib/cost.sh` accumulates per-phase token estimates from config baselines; `calibrate` subcommand for drift correction
- **PR-B** — `scripts/lib/router.sh` maps detected stack per task to specialist agent (swift-expert, typescript-pro, python-pro, rust-expert, go-expert) with graceful fallback to `feature-marker`; routing cached in `.orchestrator/stack-map.json`
- **PR-C** — `scripts/lib/learning.sh` implements 3-tier store (feature/project/global) with TTL sweep, confidence scoring, and the full capture→apply→verify→prune→promote loop; `dep_check_merge_state()` hard-blocks dependent features until parent PR is merged (via gh/az/glab); new `learning` and `promote-learning` subcommands
- **PR-D** — `scripts/lib/size_gate.sh` reads PRD/tasks/techspec metrics against `safety.feature_size` thresholds; `scripts/lib/cycle_gate.sh` asserts complete cycle before advancing; `--skip-cycle-check` escape hatch added

Expected token savings: ~40% on the happy path per ADR-008 model.

## Test plan

- [ ] `bash -n` passes on all 7 new/modified shell files (verified)
- [ ] `orchestrate.sh --help` shows all new subcommands/flags (verified)
- [ ] `orchestrate.sh calibrate` runs without error (verified)
- [ ] `orchestrate.sh learning list` runs without error (verified)
- [ ] `orchestrate.sh run --dry-run` loads backlog and shows plan (verified)
- [ ] Run `orchestrate.sh run` against a project with existing PRD artifacts and confirm Phase 0 cost is 0 in logs
- [ ] Run against a project with a passing test suite and confirm Phase 3 runs script-only (no Claude tokens)
- [ ] Run with a feature that has `Depends on:` and verify hard-block fires before parent PR merges
- [ ] Create a feature with >15 acceptance criteria and verify size gate triggers
- [ ] Verify `learning list --candidates` shows entries with confidence >= 0.8 after a fix-attempt cycle
