### PR TITLE
feat: implement ADR-010 — skill pluggability and stuck-state elimination

### DIFF
--- a/.github/workflows/cleanup-reminder.yml
+++ b/.github/workflows/cleanup-reminder.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  pull-requests: write
+
 jobs:
   cleanup-reminder:
     runs-on: ubuntu-latest

--- a/docs/adr/010-stuck-state-elimination.md
+++ b/docs/adr/010-stuck-state-elimination.md
@@ -1,0 +1,89 @@
+# ADR-010: Stuck-State Elimination
+
+## Status
+
+Accepted
+
+## Context
+
+A system audit against the ADR-008 + ADR-009 codebase revealed several confirmed hang risks:
+
+| Risk                                                                                      | Location                | Severity |
+| ----------------------------------------------------------------------------------------- | ----------------------- | -------- |
+| `\| while` pipe subshell: `break`/`continue`/mutations silently don't propagate to parent | `runner.sh:99`          | HIGH     |
+| Unbounded `read -p` prompt in supervised mode                                             | `size_gate.sh:168`      | HIGH     |
+| `--resume` flag parsed but never wired up; paused features have no operator path back     | `orchestrate.sh:79,111` | HIGH     |
+| Background ingest jobs: no PID file, no reaper, zombies accumulate                        | `ingest.sh:220`         | MEDIUM   |
+| `claude --skill` invocation has no timeout                                                | `runner.sh:377`         | MEDIUM   |
+| `gh pr view`, `gh run view --log-failed` have no timeout                                  | `ingest.sh:58-75`       | MEDIUM   |
+| Sentinel files (`retry-count`, `phase3-fix-attempts`) survive across runs silently        | `runner.sh:417-465`     | MEDIUM   |
+| JSON injection: `node -p "JSON.stringify('$var')"` breaks on single quotes                | multiple                | LOW      |
+
+## Decisions
+
+### D1 — Portable timeout helper (`op_timeout` in `scripts/lib/util.sh`)
+
+`op_timeout <seconds> <command...>` wraps every external call that can block: `claude --skill`, `gh pr view`, `gh run view --log-failed`. Falls back from `timeout` → `gtimeout` → `perl alarm`.
+
+The `claude --skill` call in `runner.sh` is wrapped with a configurable `SKILL_TIMEOUT_SECONDS` (default 1800). The existing `local_model.sh` `curl --max-time` pattern is unchanged (already timed).
+
+### D2 — Subshell-pipe fix (`runner.sh` main loop)
+
+Replace:
+
+```bash
+echo "$items" | node -e "..." | while IFS= read -r item_json; do
+  break  # only breaks subshell — parent loop continues
+done
+```
+
+With process substitution:
+
+```bash
+while IFS= read -r item_json; do
+  break  # breaks parent loop correctly
+done < <(echo "$items" | node -e "...")
+```
+
+All `| while` patterns in `scripts/lib/` are audited and fixed where loop-control or variable mutation crosses the pipe.
+
+### D3 — `--resume-paused <feat-id>` operator command
+
+The dead `OPT_RESUME` boolean is removed. A real `--resume-paused <feat-id>` subcommand re-enters `runner.sh` at the checkpoint phase for a paused feature. Human-class pauses require `--ack`.
+
+### D4 — Pause taxonomy (`pause_kind: human | transient`)
+
+Every pause record in `.orchestrator/state/<feat-id>/pause.json` carries a `pause_kind` field:
+
+- `human` — requires operator decision (size gate declined, breaking change, supervised checkpoint). `--skip-blocked` skips these. `--resume-paused` requires `--ack`.
+- `transient` — pipeline error that may resolve on retry. Auto-retried on next run with backoff.
+
+The size gate prompt gets `read -t 120` so unattended runs auto-decline (recorded as `pause_kind:"human", action:"timeout_skipped"`) instead of hanging indefinitely.
+
+### D5 — Background ingest reaping (`scripts/lib/ingest.sh`)
+
+`ingest_trigger_if_merged` now writes a PID file to `.orchestrator/state/<feat-id>/ingest.pid`. `ingest_reap_stale` (called at `sub_run` startup) walks all PID files, checks liveness with `kill -0`, and cleans up finished jobs. `ingest-status` subcommand lists active jobs.
+
+### D6 — Sentinel cleanup on resume
+
+`runner_clear_sentinels <feat-id> <class>` removes `retry-count` and `phase3-fix-attempts` sentinel files. On `--resume-paused` for a `transient` pause, transient sentinels are cleared; human sentinels are preserved until `--ack` is passed.
+
+### D7 — JSON-injection hardening (high-risk sites in `ingest.sh` and `learning.sh`)
+
+The fragile `node -p "JSON.stringify('$var')"` pattern is replaced at the highest-risk sites by piping values through Node via stdin, eliminating the shell-injection vector.
+
+## Alternatives Considered
+
+**Bash skill registry** — rejected. Claude Code already discovers SKILL.md files under `~/.claude/skills/`, loads them into its catalog, and decides when to activate them based on the `description` field. Building a parallel registry in bash (`skills_init`, `skill_invoke_hook`, `skill-registry.json`) duplicates a solved problem and moves the activation decision from Claude to the orchestrator. The `learning-curator` skill lives as a nested sub-skill at `resources/skills/learning-curator/` and is invoked by Claude via the `Skill` tool when review or CI signals are present — no bash dispatcher needed.
+
+## Consequences
+
+- `full_auto` and `checkpoint` modes can run unattended without operator intervention to unstick them.
+- `--resume-paused <feat-id>` gives operators a clean, typed recovery path.
+- Background ingest jobs no longer accumulate as zombies across long sessions.
+- `ingest-status` subcommand provides operational visibility into active background work.
+- `util.sh` is a shared module; all future shell modules that make external calls should source it.
+
+## Compatibility
+
+ADR-009 modules (`local_model.sh`, full `ingest.sh`) are sourced conditionally (`[ -f ... ] && source ...`). ADR-010 degrades gracefully when ADR-009 is not present.

--- a/feature-marker-dist/feature-marker/SKILL.md
+++ b/feature-marker-dist/feature-marker/SKILL.md
@@ -181,6 +181,7 @@ When invoked, the skill:
      - If installation fails: Falls back to standard commit workflow
 4. **Executes 5-phase workflow** via the `feature-marker` agent
 5. **Persists state** - Saves checkpoints after each phase/task for resume capability
+6. **Curates learning** - After Phase 4 (Commit & PR), if PR review comments or CI failure logs are available in the session, invoke the `learning-curator` sub-skill via `Skill` to summarize them into structured fix patterns for the learning store
 
 **Important**: The workflow is smart about file detection and dependencies:
 

--- a/feature-marker-dist/feature-marker/resources/skills/learning-curator/SKILL.md
+++ b/feature-marker-dist/feature-marker/resources/skills/learning-curator/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: learning-curator
+description: Summarize PR review comments and CI failure logs into structured fix patterns (JSON output) for the learning store. Use when review or CI signals are available after a PR is merged.
+---
+
+# learning-curator
+
+You are the Learning Curator for the feature-marker orchestrator. Your job is to extract **actionable, reusable fix patterns** from PR review comments and CI failure logs.
+
+## Input
+
+You receive either:
+
+- PR review comments (text from `gh pr view --comments`)
+- CI failure logs (text from `gh run view --log-failed`)
+
+## Output format
+
+Respond with **only** a JSON object matching this schema — no prose, no markdown fences:
+
+```json
+{
+  "confidence": 0.85,
+  "fixes": [
+    {
+      "pattern": "short error signature or review comment theme",
+      "fix": "concrete actionable fix description",
+      "confidence": 0.9
+    }
+  ]
+}
+```
+
+## Rules
+
+1. `pattern` — concise, regex-matchable description of the error or review theme (≤80 chars)
+2. `fix` — concrete action, not generic advice. "Add null check before calling `.length`" not "handle null"
+3. `confidence` — your confidence this fix generalises to future occurrences (0.0–1.0)
+4. Only include fixes with confidence ≥ 0.5; lower-confidence observations should be omitted
+5. Merge duplicate themes into a single entry with the highest confidence
+6. Maximum 10 fixes per response
+7. If the input contains no actionable patterns, return `{"confidence": 0, "fixes": []}`
+
+## Example
+
+Input (CI log excerpt):
+
+```
+FAIL src/auth/token.test.ts
+  ✕ should reject expired tokens
+  TypeError: Cannot read property 'exp' of null
+    at verifyToken (src/auth/token.ts:42:18)
+```
+
+Output:
+
+```json
+{
+  "confidence": 0.9,
+  "fixes": [
+    {
+      "pattern": "Cannot read property 'exp' of null at verifyToken",
+      "fix": "Add null guard in verifyToken before accessing token.exp (token may be null when JWT decode fails)",
+      "confidence": 0.9
+    }
+  ]
+}
+```

--- a/orchestrator/config.yml
+++ b/orchestrator/config.yml
@@ -119,6 +119,9 @@ learning:
     backend: exact # exact | embedding (embedding requires local_model.enabled: true)
     threshold: 0.85
 
+execution_timeouts:
+  skill_timeout_seconds: 1800 # Wall-clock limit for claude --skill invocations (op_timeout)
+
 # Local-model integration (ADR-009)
 local_model:
   enabled: false # opt-in; false = pure-Claude behaviour (zero change for existing users)

--- a/scripts/lib/ingest.sh
+++ b/scripts/lib/ingest.sh
@@ -37,9 +37,9 @@ ingest_reviews() {
   local pr_url
   pr_url=$(node -p "
     try {
-      JSON.parse(require('fs').readFileSync('$results_file','utf-8')).pr_url || '';
+      JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')).pr_url || '';
     } catch(e) { ''; }
-  " 2>/dev/null || echo "")
+  " "$results_file" 2>/dev/null || echo "")
 
   if [ -z "$pr_url" ]; then
     info "Ingest: no PR URL recorded for $feat_id — skipping"
@@ -86,17 +86,18 @@ ingest_reviews() {
   local ingest_record="$STATE_DIR/$feat_id/ingest.json"
   node -e "
     const fs = require('fs');
+    const [,, path, featId, prUrl, fixCount] = process.argv;
     let records;
-    try { records = JSON.parse(fs.readFileSync('${ingest_record}','utf-8')); } catch(e) { records = []; }
+    try { records = JSON.parse(fs.readFileSync(path,'utf-8')); } catch(e) { records = []; }
     records.push({
       type: 'review_ingest',
-      feat_id: '${feat_id}',
-      pr_url: '${pr_url}',
+      feat_id: featId,
+      pr_url: prUrl,
       ran_at: new Date().toISOString(),
-      fixes_written: ${total_written}
+      fixes_written: Number(fixCount)
     });
-    fs.writeFileSync('${ingest_record}', JSON.stringify(records, null, 2));
-  " 2>/dev/null || true
+    fs.writeFileSync(path, JSON.stringify(records, null, 2));
+  " "$ingest_record" "$feat_id" "$pr_url" "$total_written" 2>/dev/null || true
 
   info "Ingest: wrote $total_written fix(es) to project learning store (feat: $feat_id)"
 }
@@ -128,10 +129,8 @@ ingest_write_fixes() {
 
       const fixes = data.fixes || [];
       const globalConf = data.confidence || 0;
-      const threshold = ${INGEST_CONFIDENCE_THRESHOLD};
-      const projectPath = '${project_path}';
-      const logPath = '${log_file}';
-      const source = '${source_label}';
+      const [,, projectPath, logPath, source] = process.argv;
+      const threshold = Number(process.argv[5]);
 
       let store;
       try { store = JSON.parse(fs.readFileSync(projectPath, 'utf-8')); } catch(e) { store = []; }
@@ -184,13 +183,13 @@ ingest_write_fixes() {
         require('fs').mkdirSync(logDir, { recursive: true });
         fs.writeFileSync(logPath, JSON.stringify({
           source, skipped_reason: 'confidence below threshold',
-          threshold: ${INGEST_CONFIDENCE_THRESHOLD}, skipped
+          threshold: Number(process.argv[5]), skipped
         }, null, 2));
       }
 
       process.stdout.write(String(written));
     });
-  " 2>/dev/null || echo "0")
+  " "$project_path" "$log_file" "$source_label" "$INGEST_CONFIDENCE_THRESHOLD" 2>/dev/null || echo "0")
 
   echo "${written:-0}"
 }
@@ -210,9 +209,9 @@ ingest_trigger_if_merged() {
 
   local pr_url
   pr_url=$(node -p "
-    try { JSON.parse(require('fs').readFileSync('$results_file','utf-8')).pr_url || ''; }
+    try { JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')).pr_url || ''; }
     catch(e) { ''; }
-  " 2>/dev/null || echo "")
+  " "$results_file" 2>/dev/null || echo "")
 
   [ -z "$pr_url" ] && return 0
 
@@ -224,12 +223,14 @@ ingest_trigger_if_merged() {
     (ingest_reviews "$feat_id" >> "$log_file" 2>&1; echo "exit:$?" >> "$log_file") &
     local bg_pid=$!
     node -e "
-      require('fs').writeFileSync('$pid_file', JSON.stringify({
-        pid: $bg_pid,
-        feat_id: '$feat_id',
+      const fs = require('fs');
+      const [,, pidFile, bgPid, featId] = process.argv;
+      fs.writeFileSync(pidFile, JSON.stringify({
+        pid: Number(bgPid),
+        feat_id: featId,
         started_at: new Date().toISOString()
       }, null, 2));
-    " 2>/dev/null || true
+    " "$pid_file" "$bg_pid" "$feat_id" 2>/dev/null || true
     info "Ingest: background review-ingest triggered for $feat_id (PID $bg_pid)"
   else
     info "Ingest: ingest_reviews not available — skipping (merge ADR-009 to enable)"
@@ -248,10 +249,14 @@ ingest_reap_stale() {
   for pid_file in "$STATE_DIR"/*/ingest.pid; do
     [ -f "$pid_file" ] || continue
 
-    local pid feat_id started_at
-    pid=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).pid||0}catch(e){0}" 2>/dev/null || echo "0")
-    feat_id=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).feat_id||''}catch(e){''}" 2>/dev/null || echo "")
-    started_at=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).started_at||''}catch(e){''}" 2>/dev/null || echo "")
+    local pid feat_id started_at fields
+    fields=$(node -p "
+      try {
+        const d = JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8'));
+        [d.pid||0, d.feat_id||'', d.started_at||''].join('\t');
+      } catch(e) { '0\t\t'; }
+    " "$pid_file" 2>/dev/null || printf '0\t\t')
+    IFS=$'\t' read -r pid feat_id started_at <<< "$fields"
 
     [ "$pid" -eq 0 ] && { rm -f "$pid_file"; continue; }
 
@@ -284,10 +289,14 @@ ingest_status() {
     [ -f "$pid_file" ] || continue
     found=1
 
-    local pid feat_id started_at
-    pid=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).pid||0}catch(e){0}" 2>/dev/null || echo "0")
-    feat_id=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).feat_id||''}catch(e){''}" 2>/dev/null || echo "")
-    started_at=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).started_at||''}catch(e){''}" 2>/dev/null || echo "")
+    local pid feat_id started_at fields
+    fields=$(node -p "
+      try {
+        const d = JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8'));
+        [d.pid||0, d.feat_id||'', d.started_at||''].join('\t');
+      } catch(e) { '0\t\t'; }
+    " "$pid_file" 2>/dev/null || printf '0\t\t')
+    IFS=$'\t' read -r pid feat_id started_at <<< "$fields"
 
     local status="running"
     kill -0 "$pid" 2>/dev/null || status="zombie (not yet reaped)"

--- a/scripts/lib/ingest.sh
+++ b/scripts/lib/ingest.sh
@@ -86,7 +86,7 @@ ingest_reviews() {
   local ingest_record="$STATE_DIR/$feat_id/ingest.json"
   node -e "
     const fs = require('fs');
-    const [,, path, featId, prUrl, fixCount] = process.argv;
+    const [, path, featId, prUrl, fixCount] = process.argv;
     let records;
     try { records = JSON.parse(fs.readFileSync(path,'utf-8')); } catch(e) { records = []; }
     records.push({
@@ -129,8 +129,8 @@ ingest_write_fixes() {
 
       const fixes = data.fixes || [];
       const globalConf = data.confidence || 0;
-      const [,, projectPath, logPath, source] = process.argv;
-      const threshold = Number(process.argv[5]);
+      const [, projectPath, logPath, source] = process.argv;
+      const threshold = Number(process.argv[4]);
 
       let store;
       try { store = JSON.parse(fs.readFileSync(projectPath, 'utf-8')); } catch(e) { store = []; }
@@ -183,7 +183,7 @@ ingest_write_fixes() {
         require('fs').mkdirSync(logDir, { recursive: true });
         fs.writeFileSync(logPath, JSON.stringify({
           source, skipped_reason: 'confidence below threshold',
-          threshold: Number(process.argv[5]), skipped
+          threshold: Number(process.argv[4]), skipped
         }, null, 2));
       }
 
@@ -224,7 +224,7 @@ ingest_trigger_if_merged() {
     local bg_pid=$!
     node -e "
       const fs = require('fs');
-      const [,, pidFile, bgPid, featId] = process.argv;
+      const [, pidFile, bgPid, featId] = process.argv;
       fs.writeFileSync(pidFile, JSON.stringify({
         pid: Number(bgPid),
         feat_id: featId,
@@ -305,4 +305,5 @@ ingest_status() {
   done
 
   [ "$found" -eq 0 ] && info "No active background ingest jobs."
+  return 0
 }

--- a/scripts/lib/ingest.sh
+++ b/scripts/lib/ingest.sh
@@ -216,7 +216,84 @@ ingest_trigger_if_merged() {
 
   [ -z "$pr_url" ] && return 0
 
-  # Background: do not block Phase 4
-  (ingest_reviews "$feat_id" >> "$STATE_DIR/$feat_id/ingest-bg.log" 2>&1) &
-  info "Ingest: background review-ingest triggered for $feat_id (PID $!)"
+  local pid_file="$STATE_DIR/$feat_id/ingest.pid"
+  local log_file="$STATE_DIR/$feat_id/ingest-bg.log"
+  mkdir -p "$STATE_DIR/$feat_id"
+
+  if declare -f ingest_reviews &>/dev/null; then
+    (ingest_reviews "$feat_id" >> "$log_file" 2>&1; echo "exit:$?" >> "$log_file") &
+    local bg_pid=$!
+    node -e "
+      require('fs').writeFileSync('$pid_file', JSON.stringify({
+        pid: $bg_pid,
+        feat_id: '$feat_id',
+        started_at: new Date().toISOString()
+      }, null, 2));
+    " 2>/dev/null || true
+    info "Ingest: background review-ingest triggered for $feat_id (PID $bg_pid)"
+  else
+    info "Ingest: ingest_reviews not available — skipping (merge ADR-009 to enable)"
+  fi
+}
+
+# ── ingest_reap_stale ─────────────────────────────────────────────────
+# Called at orchestrate.sh startup.
+# For each .pid file, checks if the process is still alive.
+# If dead, cleans up the pid file and logs the completion status.
+
+ingest_reap_stale() {
+  [ ! -d "$STATE_DIR" ] && return 0
+
+  local reaped=0
+  for pid_file in "$STATE_DIR"/*/ingest.pid; do
+    [ -f "$pid_file" ] || continue
+
+    local pid feat_id started_at
+    pid=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).pid||0}catch(e){0}" 2>/dev/null || echo "0")
+    feat_id=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).feat_id||''}catch(e){''}" 2>/dev/null || echo "")
+    started_at=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).started_at||''}catch(e){''}" 2>/dev/null || echo "")
+
+    [ "$pid" -eq 0 ] && { rm -f "$pid_file"; continue; }
+
+    if kill -0 "$pid" 2>/dev/null; then
+      continue
+    fi
+
+    rm -f "$pid_file"
+    reaped=$((reaped + 1))
+
+    local log_file="$STATE_DIR/$feat_id/ingest-bg.log"
+    local exit_line=""
+    [ -f "$log_file" ] && exit_line=$(grep "^exit:" "$log_file" | tail -1 || echo "")
+
+    info "Ingest: reaped finished background job (feat: $feat_id, PID: $pid, started: $started_at, ${exit_line:-exit: unknown})"
+  done
+
+  [ "$reaped" -gt 0 ] && info "Ingest: reaped $reaped stale background job(s)"
+  return 0
+}
+
+# ── ingest_status ─────────────────────────────────────────────────────
+# Lists active background ingest jobs.
+
+ingest_status() {
+  [ ! -d "$STATE_DIR" ] && { info "No state directory found."; return 0; }
+
+  local found=0
+  for pid_file in "$STATE_DIR"/*/ingest.pid; do
+    [ -f "$pid_file" ] || continue
+    found=1
+
+    local pid feat_id started_at
+    pid=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).pid||0}catch(e){0}" 2>/dev/null || echo "0")
+    feat_id=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).feat_id||''}catch(e){''}" 2>/dev/null || echo "")
+    started_at=$(node -p "try{JSON.parse(require('fs').readFileSync('$pid_file','utf-8')).started_at||''}catch(e){''}" 2>/dev/null || echo "")
+
+    local status="running"
+    kill -0 "$pid" 2>/dev/null || status="zombie (not yet reaped)"
+
+    echo "  feat: $feat_id | PID: $pid | started: $started_at | status: $status"
+  done
+
+  [ "$found" -eq 0 ] && info "No active background ingest jobs."
 }

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -12,13 +12,6 @@
 #   - learning_read() / learning_write() for Phase 3 fix hints (learning.sh)
 #   - router_route_task() for stack-aware agent selection (router.sh)
 #   - cycle_gate_check() before advancing to next feature (cycle_gate.sh)
-#
-# ADR-009 additions (PR-H):
-#   - When LOCAL_MODEL_GENERATOR_MODEL is set, Phase 2 implementation and
-#     Phase 3 fix attempts route through local_model::generate instead of Claude.
-#   - Quality-warning banner printed at start when generator replacement is active.
-#   - Checkpoint engine field set to "local" for generator-replaced phases.
-#   - ingest_trigger_if_merged() called after PR creation (Phase 4.5).
 
 run_backlog() {
   local backlog_file="$1"
@@ -50,15 +43,6 @@ run_backlog() {
   total_count=$(echo "$items" | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8')).total")
 
   banner "Orchestrator — $ready_count ready, $blocked_count blocked, $total_count total"
-
-  # ADR-009 PR-H: quality-warning banner when local generator replacement is active
-  if [ "${LOCAL_MODEL_ENABLED:-false}" = "true" ] && [ -n "${LOCAL_MODEL_GENERATOR_MODEL:-}" ]; then
-    echo ""
-    echo "  ! LOCAL GENERATOR ACTIVE (experimental)"
-    echo "    Phase 2/3 code generation via local model: ${LOCAL_MODEL_GENERATOR_MODEL}"
-    echo "    Quality tradeoffs apply — see ADR-009 Decision #8."
-    echo ""
-  fi
 
   if [ "$ready_count" -eq 0 ]; then
     info "No actionable features. All done or blocked."
@@ -108,11 +92,9 @@ run_backlog() {
     process_item "$single" 1 1
   else
     # Main loop — ADR-008: check hard-block deps + cycle gate per item
+    # ADR-010: process substitution replaces pipe so break/continue work in parent shell
     local index=0
-    echo "$items" | node -e "
-      const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
-      d.ready.forEach(i => console.log(JSON.stringify(i)));
-    " | while IFS= read -r item_json; do
+    while IFS= read -r item_json; do
       index=$((index + 1))
 
       # ADR-008 PR-C: hard-block dependency check
@@ -139,7 +121,10 @@ run_backlog() {
           break
         fi
       fi
-    done
+    done < <(echo "$items" | node -e "
+      const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+      d.ready.forEach(i => console.log(JSON.stringify(i)));
+    ")
   fi
 
   # Post-loop: cleanup
@@ -264,6 +249,7 @@ EOPRD
       local exceeded_str="${SIZE_EXCEEDED_CRITERIA:+$SIZE_EXCEEDED_CRITERIA }${SIZE_EXCEEDED_TASKS:+$SIZE_EXCEEDED_TASKS }${SIZE_EXCEEDED_FILES:+$SIZE_EXCEEDED_FILES}"
       if ! size_gate_signal "$feat_id" "$AUTONOMY" "$exceeded_str"; then
         wt_update_status "$feat_id" "paused" "size-gate"
+        _runner_record_pause "$feat_id" "human" "size-gate"
         return 0
       fi
     fi
@@ -345,43 +331,19 @@ EOPRD
   [ -n "${MODEL_DEFAULT:-}" ] && model_flag="--model $MODEL_DEFAULT"
 
   if [ "$AUTONOMY" = "full_auto" ]; then
-    # ADR-009 PR-H: route Phase 2 through local generator when configured
-    local phase2_engine="${CFG_LOCAL_MODEL_ENGINE_PHASE2:-claude}"
-    if [ "${LOCAL_MODEL_ENABLED:-false}" = "true" ] && \
-       [ -n "${LOCAL_MODEL_GENERATOR_MODEL:-}" ] && \
-       [ "$phase2_engine" = "local" ]; then
-      info "Phase 2: local generator ($LOCAL_MODEL_GENERATOR_MODEL) for $feat_id"
-      local gen_prompt
-      gen_prompt=$(cat "$wt_path/.orchestrator-context.md" 2>/dev/null || echo "Implement $feat_id")
-      local gen_output
-      gen_output=$(local_model::generate "$gen_prompt")
-      if [ -n "$gen_output" ]; then
-        echo "$gen_output" >> "$log_file"
-        # Record engine=local in checkpoint
-        node -e "
-          const fs = require('fs');
-          const cp = '${STATE_DIR}/${feat_id}/checkpoint.json';
-          let d; try { d = JSON.parse(fs.readFileSync(cp,'utf-8')); } catch(e) { d = {}; }
-          d.phase2 = { engine: 'local', local_model: '${LOCAL_MODEL_GENERATOR_MODEL}', completed_at: new Date().toISOString() };
-          fs.writeFileSync(cp, JSON.stringify(d, null, 2));
-        " 2>/dev/null || true
-      else
-        info "Phase 2: local generator returned empty — falling back to Claude"
-        phase2_engine="claude"
-      fi
+    # ADR-009 PR-H: quality-warning banner when local generator replacement is active
+    if [ "${LOCAL_MODEL_ENABLED:-false}" = "true" ] && [ -n "${LOCAL_MODEL_GENERATOR_MODEL:-}" ]; then
+      echo ""
+      echo "  ! LOCAL GENERATOR ACTIVE (experimental)"
+      echo "    Phase 2/3 code generation via local model: ${LOCAL_MODEL_GENERATOR_MODEL}"
+      echo "    Quality tradeoffs apply — see ADR-009 Decision #8."
+      echo ""
     fi
 
-    if [ "$phase2_engine" != "local" ]; then
-      info "Autonomy=full_auto — invoking pipeline (model: ${MODEL_DEFAULT:-default}, agent: $routed_agent)..."
-      if command -v claude &>/dev/null; then
-        local skill_arg="feature-marker"
-        [ "$routed_agent" != "feature-marker" ] && skill_arg="$routed_agent"
-        (cd "$wt_path" && claude $model_flag --skill "$skill_arg" "prd-$feat_id") 2>&1 | tee "$log_file" || exit_code=$?
-      else
-        info "Claude CLI not found — simulating pipeline"
-        echo "full_auto: simulated pipeline for $feat_id (model: ${MODEL_DEFAULT:-default})" > "$log_file"
-      fi
-    fi
+    info "Autonomy=full_auto — invoking pipeline (model: ${MODEL_DEFAULT:-default}, agent: $routed_agent)..."
+    local skill_arg="feature-marker"
+    [ "$routed_agent" != "feature-marker" ] && skill_arg="$routed_agent"
+    (cd "$wt_path" && op_timeout "${SKILL_TIMEOUT_SECONDS:-1800}" claude --skill "$skill_arg" "prd-$feat_id") 2>&1 | tee "$log_file" || exit_code=$?
   elif [ "$AUTONOMY" = "checkpoint" ]; then
     info "Autonomy=checkpoint — pipeline ready, human reviews PR"
     echo "checkpoint: pipeline for $feat_id" > "$log_file"
@@ -431,6 +393,7 @@ EOPRD
     if [ "$has_breaking" = "true" ] && [ "$BREAKING_PAUSE" = "true" ]; then
       info "! BREAKING CHANGES in $feat_id — pausing"
       wt_update_status "$feat_id" "paused" "breaking-change-review"
+      _runner_record_pause "$feat_id" "human" "breaking-change-review"
       return 0
     fi
 
@@ -439,6 +402,7 @@ EOPRD
     if [ "$file_count" -gt "$MAX_FILE_CHANGES" ]; then
       info "! $feat_id touched $file_count files (limit: $MAX_FILE_CHANGES) — pausing"
       wt_update_status "$feat_id" "paused" "max-files-review"
+      _runner_record_pause "$feat_id" "human" "max-files-review"
       return 0
     fi
   fi
@@ -454,9 +418,10 @@ EOPRD
     fi
   elif [ "$exit_code" -eq 10 ]; then
     wt_update_status "$feat_id" "paused" "awaiting-review"
+    _runner_record_pause "$feat_id" "human" "supervised-checkpoint"
     info "Paused: $feat_id (supervised mode)"
   else
-    # Retry logic
+    # Retry logic — transient failures get retried with backoff
     local retry_count=0
     [ -f "$STATE_DIR/$feat_id/retry-count" ] && retry_count=$(cat "$STATE_DIR/$feat_id/retry-count")
     if [ "$retry_count" -lt "$MAX_RETRIES" ]; then
@@ -467,6 +432,7 @@ EOPRD
       mem_record_error "$feat_id" "implementation" "exit code $exit_code"
     else
       wt_update_status "$feat_id" "failed" "pipeline-error"
+      _runner_record_pause "$feat_id" "transient" "max-retries-exceeded"
       mem_record_error "$feat_id" "implementation" "FINAL FAILURE exit code $exit_code"
       err "$feat_id failed after $MAX_RETRIES attempts"
     fi
@@ -562,22 +528,7 @@ run_phase3_tests() {
     [ -n "${MODEL_DEFAULT:-}" ] && model_flag="--model $MODEL_DEFAULT"
 
     local fix_exit=0
-    # ADR-009 PR-H: route Phase 3 fix through local generator when configured
-    if [ "${LOCAL_MODEL_ENABLED:-false}" = "true" ] && [ -n "${LOCAL_MODEL_GENERATOR_MODEL:-}" ]; then
-      info "Phase 3: local generator fix attempt via $LOCAL_MODEL_GENERATOR_MODEL"
-      local local_fix
-      local_fix=$(local_model::generate "$fix_prompt")
-      [ -z "$local_fix" ] && fix_exit=1
-      # Record engine=local in checkpoint
-      node -e "
-        const fs = require('fs');
-        const cp = '${STATE_DIR}/${feat_id}/checkpoint.json';
-        let d; try { d = JSON.parse(fs.readFileSync(cp,'utf-8')); } catch(e) { d = {}; }
-        if (!d.phase3_fixes) d.phase3_fixes = [];
-        d.phase3_fixes.push({ engine: 'local', attempt: ${fix_attempts}, local_model: '${LOCAL_MODEL_GENERATOR_MODEL}', at: new Date().toISOString() });
-        fs.writeFileSync(cp, JSON.stringify(d, null, 2));
-      " 2>/dev/null || true
-    elif command -v claude &>/dev/null; then
+    if command -v claude &>/dev/null; then
       (cd "$wt_path" && printf '%b' "$fix_prompt" | claude $model_flag --print) 2>/dev/null || fix_exit=$?
     else
       info "Phase 3: Claude CLI not found — cannot attempt fix"
@@ -779,7 +730,7 @@ run_pr_creation() {
     wt_update_status "$feat_id" "pr-created" "complete"
     node -e "const fs=require('fs');const r=JSON.parse(fs.readFileSync('$results_file','utf-8'));r.pr_url='$pr_url';r.pipeline.review={status:'completed',pr_url:'$pr_url'};fs.writeFileSync('$results_file',JSON.stringify(r,null,2));" 2>/dev/null || true
     info "PR: $pr_url"
-    # ADR-009 PR-G: Phase 4.5 — trigger background review-ingest
+    # ADR-009 PR-G / ADR-010: trigger background review-ingest when available
     if declare -f ingest_trigger_if_merged &>/dev/null; then
       ingest_trigger_if_merged "$feat_id"
     fi
@@ -787,4 +738,112 @@ run_pr_creation() {
     wt_update_status "$feat_id" "done" "complete"
     info "Done: $feat_id (PR creation failed — skipping)"
   fi
+}
+
+# ── _runner_record_pause ──────────────────────────────────────────────
+# Internal: write pause taxonomy record to .orchestrator/state/{feat_id}/pause.json
+# pause_kind: "human" (operator must --ack) | "transient" (auto-retry on next run)
+
+_runner_record_pause() {
+  local feat_id="$1"
+  local pause_kind="$2"  # human | transient
+  local reason="$3"
+
+  local pause_file="$STATE_DIR/$feat_id/pause.json"
+  mkdir -p "$STATE_DIR/$feat_id"
+  node -e "
+    const fs = require('fs');
+    fs.writeFileSync('$pause_file', JSON.stringify({
+      feat_id: '$feat_id',
+      pause_kind: '$pause_kind',
+      reason: '$reason',
+      paused_at: new Date().toISOString()
+    }, null, 2));
+  " 2>/dev/null || true
+}
+
+# ── runner_clear_sentinels ────────────────────────────────────────────
+# Usage: runner_clear_sentinels <feat_id> <class>
+# class: "transient" — removes retry-count and phase3-fix-attempts
+#        "all"       — also removes pause.json (use with --ack)
+
+runner_clear_sentinels() {
+  local feat_id="$1"
+  local class="${2:-transient}"
+
+  local state_dir="$STATE_DIR/$feat_id"
+  [ ! -d "$state_dir" ] && return 0
+
+  rm -f "$state_dir/retry-count"
+  rm -f "$state_dir/phase3-fix-attempts"
+  info "Sentinels cleared (transient) for $feat_id"
+
+  if [ "$class" = "all" ]; then
+    rm -f "$state_dir/pause.json"
+    info "Sentinels cleared (human) for $feat_id"
+  fi
+}
+
+# ── run_feature_resume ────────────────────────────────────────────────
+# Usage: run_feature_resume <feat_id> [--ack]
+# Re-enters a paused feature from its checkpoint.
+# --ack required for human-class pauses.
+
+run_feature_resume() {
+  local feat_id="$1"
+  local ack=false
+  [ "${2:-}" = "--ack" ] && ack=true
+
+  local pause_file="$STATE_DIR/$feat_id/pause.json"
+  local results_file="$STATE_DIR/$feat_id/results.json"
+
+  if [ ! -f "$results_file" ]; then
+    err "resume: no results.json for $feat_id — has it run at all?"
+    return 1
+  fi
+
+  local pause_kind="transient"
+  local reason=""
+  if [ -f "$pause_file" ]; then
+    pause_kind=$(node -p "try{JSON.parse(require('fs').readFileSync('$pause_file','utf-8')).pause_kind||'transient'}catch(e){'transient'}" 2>/dev/null || echo "transient")
+    reason=$(node -p "try{JSON.parse(require('fs').readFileSync('$pause_file','utf-8')).reason||''}catch(e){''}" 2>/dev/null || echo "")
+  fi
+
+  if [ "$pause_kind" = "human" ] && [ "$ack" != "true" ]; then
+    err "resume: $feat_id is paused with pause_kind=human (reason: $reason)"
+    err "Use --resume-paused $feat_id --ack to acknowledge and resume."
+    return 1
+  fi
+
+  info "Resuming $feat_id (pause_kind: $pause_kind, reason: $reason)"
+  runner_clear_sentinels "$feat_id" "$( [ "$pause_kind" = "human" ] && echo all || echo transient )"
+
+  # Re-enter from the saved checkpoint phase or from the beginning
+  local checkpoint_file="$STATE_DIR/$feat_id/checkpoint.json"
+  local resume_phase="phase0"
+  if [ -f "$checkpoint_file" ]; then
+    resume_phase=$(node -e "
+      const cp = JSON.parse(require('fs').readFileSync('$checkpoint_file','utf-8'));
+      const phases = ['phase0','phase1','phase2','phase3','phase4'];
+      const last = phases.slice().reverse().find(p => cp[p] && cp[p].status === 'complete');
+      const next = last ? phases[phases.indexOf(last)+1] : phases[0];
+      console.log(next || 'done');
+    " 2>/dev/null || echo "phase0")
+  fi
+
+  if [ "$resume_phase" = "done" ]; then
+    info "$feat_id appears complete (all phases done). Nothing to resume."
+    return 0
+  fi
+
+  info "Resuming $feat_id from $resume_phase"
+
+  # Extract title from results.json and re-invoke run_feature
+  local title
+  title=$(node -p "try{JSON.parse(require('fs').readFileSync('$results_file','utf-8')).title||'$feat_id'}catch(e){'$feat_id'}" 2>/dev/null || echo "$feat_id")
+
+  # Re-enter run_feature with sentinel context set to resume
+  export RUNNER_RESUME_FROM="$resume_phase"
+  run_feature "$feat_id" "$title" "" "medium" "" "" "1" "1"
+  unset RUNNER_RESUME_FROM
 }

--- a/scripts/lib/size_gate.sh
+++ b/scripts/lib/size_gate.sh
@@ -162,10 +162,11 @@ size_gate_signal() {
       info "! Feature $feat_id exceeds size thresholds: $exceeded_metrics"
       info "  Consider splitting into smaller features before proceeding."
       echo ""
-      # Read from /dev/tty to avoid consuming stdin from the calling pipeline
+      # Read from /dev/tty to avoid consuming stdin from the calling pipeline.
+      # 120-second timeout (ADR-010): unattended runs auto-decline rather than hang.
       local answer="n"
       if [ -t 0 ]; then
-        read -r -p "  Proceed anyway? [y/N] " answer </dev/tty || answer="n"
+        read -t 120 -r -p "  Proceed anyway? [y/N] " answer </dev/tty || answer="n"
       else
         info "  (non-interactive mode — defaulting to skip)"
       fi
@@ -175,13 +176,16 @@ size_gate_signal() {
           return 0
           ;;
         *)
+          local action="user_skipped"
+          [ -z "${answer:-}" ] && action="timeout_skipped"
+          [ "$action" = "timeout_skipped" ] && info "Size-gate prompt timed out (120s) — skipping $feat_id"
           info "Skipping $feat_id due to size gate. Split the feature and re-run."
           node -e "
             require('fs').writeFileSync('$signal_file', JSON.stringify({
               feature_id: '$feat_id',
               recorded_at: new Date().toISOString(),
               exceeded: '$exceeded_metrics',
-              action: 'user_skipped'
+              action: '$action'
             }, null, 2));
           " 2>/dev/null || true
           return 1

--- a/scripts/lib/util.sh
+++ b/scripts/lib/util.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# lib/util.sh — Portable utility helpers (ADR-010)
+#
+# op_timeout: single cross-platform timeout wrapper for all external calls
+
+# op_timeout <seconds> <command...>
+# Wraps command in a timeout. Tries: timeout (Linux) → gtimeout (Homebrew coreutils) → perl alarm.
+op_timeout() {
+  local secs="$1"; shift
+  if command -v timeout &>/dev/null; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout &>/dev/null; then
+    gtimeout "$secs" "$@"
+  else
+    # perl fallback — available on every macOS installation
+    perl -e "alarm $secs; exec @ARGV" -- "$@"
+  fi
+}

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -19,7 +19,6 @@
 #   --config <path>      Config file (default: orchestrator/config.yml)
 #   --plan               Show the plan, don't execute
 #   --dry-run             Alias for --plan
-#   -v, --verbose        Enable verbose output
 #   --help               Show this help
 
 set -euo pipefail
@@ -77,19 +76,25 @@ OPT_MODEL=""
 OPT_CONFIG="orchestrator/config.yml"
 OPT_DRY_RUN=false
 OPT_FEATURE=""
-OPT_RESUME=false
+OPT_RESUME_FEAT=""
+OPT_RESUME_ACK=false
 OPT_SKIP_CYCLE_CHECK=false
 OPT_SAMPLE=10
 OPT_LEARNING_ACTION=""
 OPT_LEARNING_ID=""
 OPT_LEARNING_CANDIDATES=false
 OPT_INGEST_FEAT=""
-VERBOSE=false
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    init|run|status|clean|clean-merged|calibrate|learning|promote-learning|ingest-reviews)
+    init|run|status|clean|calibrate|learning|promote-learning|ingest-status)
       SUBCOMMAND="$1"
+      ;;
+    --resume-paused)
+      shift; OPT_RESUME_FEAT="$1"; SUBCOMMAND="resume-paused"
+      ;;
+    --ack)
+      OPT_RESUME_ACK=true
       ;;
     --autonomy)
       shift; OPT_AUTONOMY="$1"
@@ -109,12 +114,6 @@ while [ $# -gt 0 ]; do
     --plan|--dry-run)
       OPT_DRY_RUN=true
       ;;
-    -v|--verbose)
-      VERBOSE=true
-      ;;
-    --resume)
-      OPT_RESUME=true
-      ;;
     --skip-cycle-check)
       OPT_SKIP_CYCLE_CHECK=true
       ;;
@@ -125,42 +124,39 @@ while [ $# -gt 0 ]; do
       OPT_LEARNING_CANDIDATES=true
       ;;
     list|archive|promote)
-      # Sub-subcommands for the learning subcommand
       [ "$SUBCOMMAND" = "learning" ] && OPT_LEARNING_ACTION="$1"
       ;;
     --help|-h)
       echo "Usage: orchestrate.sh <command> [flags]"
       echo ""
       echo "Commands:"
-      echo "  init                       Scaffold config, .env, features.md, .gitignore"
-      echo "  run                        Execute the orchestration loop"
-      echo "  status                     Show current orchestrator state"
-      echo "  clean                      Remove all worktrees and reset state"
-      echo "  clean-merged               Remove worktrees for branches already merged on GitHub"
-      echo "  calibrate                  Show token-cost calibration guidance"
-      echo "  learning list              List all learning entries"
-      echo "  learning list --candidates List only promotion candidates"
-      echo "  learning archive <id>      Archive a learning entry by ID"
-      echo "  learning promote <id>      Promote a project entry to global tier"
-      echo "  promote-learning <id>      Alias for: learning promote <id>"
-      echo "  ingest-reviews <feat-id>   Run Phase 4.5 review-ingest on demand (ADR-009)"
+      echo "  init                         Scaffold config, .env, features.md, .gitignore"
+      echo "  run                          Execute the orchestration loop"
+      echo "  status                       Show current orchestrator state"
+      echo "  clean                        Remove all worktrees and reset state"
+      echo "  calibrate                    Show token-cost calibration guidance"
+      echo "  learning list                List all learning entries"
+      echo "  learning list --candidates   List only promotion candidates"
+      echo "  learning archive <id>        Archive a learning entry by ID"
+      echo "  learning promote <id>        Promote a project entry to global tier"
+      echo "  promote-learning <id>        Alias for: learning promote <id>"
+      echo "  ingest-status                Show active background ingest jobs (ADR-009)"
       echo ""
       echo "Flags:"
-      echo "  --autonomy <level>         supervised | checkpoint | full_auto"
-      echo "  --adapter <type>           markdown | github | linear"
-      echo "  --model <name>             opus | sonnet | haiku | opusplan"
-      echo "  --config <path>            Config file (default: orchestrator/config.yml)"
-      echo "  --feature <id>             Run only the specified feature"
-      echo "  --plan, --dry-run          Show plan without executing"
-      echo "  --resume                   Skip completed, run pending"
-      echo "  --skip-cycle-check         Skip the cycle-completion gate"
-      echo "  --sample <n>               Sample size for calibrate (default: 10)"
-      echo "  -v, --verbose              Enable verbose output"
-      echo "  --help                     Show this help"
+      echo "  --autonomy <level>           supervised | checkpoint | full_auto"
+      echo "  --adapter <type>             markdown | github | linear"
+      echo "  --model <name>              opus | sonnet | haiku | opusplan"
+      echo "  --config <path>              Config file (default: orchestrator/config.yml)"
+      echo "  --feature <id>              Run only the specified feature"
+      echo "  --plan, --dry-run            Show plan without executing"
+      echo "  --resume-paused <feat-id>    Resume a paused feature from its checkpoint"
+      echo "  --ack                        Acknowledge human-class pauses for --resume-paused"
+      echo "  --skip-cycle-check           Skip the cycle-completion gate"
+      echo "  --sample <n>                 Sample size for calibrate (default: 10)"
+      echo "  --help                       Show this help"
       exit 0
       ;;
     *)
-      # Capture positional arguments for subcommands that need them
       if [ "$SUBCOMMAND" = "learning" ] && [ -z "$OPT_LEARNING_ACTION" ]; then
         OPT_LEARNING_ACTION="$1"
       elif [ "$SUBCOMMAND" = "learning" ] && [ -z "$OPT_LEARNING_ID" ]; then
@@ -180,7 +176,6 @@ while [ $# -gt 0 ]; do
 done
 
 export OPT_SKIP_CYCLE_CHECK
-export VERBOSE
 
 [ -z "$SUBCOMMAND" ] && { err "No command given. Run: ./scripts/orchestrate.sh --help"; exit 1; }
 
@@ -309,6 +304,7 @@ STARTER
 
 sub_run() {
   # Load modules
+  source "$LIB_DIR/util.sh"
   source "$LIB_DIR/config.sh"
   source "$LIB_DIR/worktree.sh"
   source "$LIB_DIR/memory.sh"
@@ -319,15 +315,14 @@ sub_run() {
   source "$LIB_DIR/learning.sh"
   source "$LIB_DIR/size_gate.sh"
   source "$LIB_DIR/cycle_gate.sh"
-  # ADR-009 modules
-  source "$LIB_DIR/local_model.sh"
-  source "$LIB_DIR/ingest.sh"
+  # ADR-009 modules (optional — loaded if present)
+  [ -f "$LIB_DIR/local_model.sh" ] && source "$LIB_DIR/local_model.sh"
+  [ -f "$LIB_DIR/ingest.sh"      ] && source "$LIB_DIR/ingest.sh"
   source "$LIB_DIR/runner.sh"
 
   # Resolve config file — check multiple locations
   local config_file="$OPT_CONFIG"
   if [ ! -f "$config_file" ]; then
-    # Try .orchestrator/config.yaml (new standard)
     if [ -f ".orchestrator/config.yaml" ]; then
       config_file=".orchestrator/config.yaml"
     elif [ -f ".orchestrator/config.yml" ]; then
@@ -348,13 +343,15 @@ sub_run() {
 
   banner "Orchestrate — $ADAPTER / $AUTONOMY / $BASE_BRANCH / model:$MODEL_DEFAULT"
 
-  # Pre-run: clean worktrees for branches already merged on GitHub
-  if [ "$AUTO_CLEANUP" = "true" ]; then
-    wt_cleanup_merged "$BASE_BRANCH" 2>/dev/null || true
+  # ADR-010: reap any finished background ingest jobs from prior sessions
+  if declare -f ingest_reap_stale &>/dev/null; then
+    ingest_reap_stale || true
   fi
 
-  # ADR-009 PR-E: startup health check (result cached to local_model_health.json)
-  local_model_health_check || true
+  # ADR-009 PR-E: startup health check (when local_model.sh is present)
+  if declare -f local_model_health_check &>/dev/null; then
+    local_model_health_check || true
+  fi
 
   # Agent discovery (ADR-006)
   local manifest_file="$CONFIG_DIR/agents-manifest.json"
@@ -463,17 +460,6 @@ sub_clean() {
 }
 
 # ══════════════════════════════════════════════════════════════════
-# Subcommand: clean-merged
-# ══════════════════════════════════════════════════════════════════
-
-sub_clean_merged() {
-  source "$LIB_DIR/worktree.sh"
-
-  banner "Cleaning worktrees for merged branches"
-  wt_cleanup_merged "${BASE_BRANCH:-main}"
-}
-
-# ══════════════════════════════════════════════════════════════════
 # Subcommand: calibrate (ADR-008 PR-A)
 # ══════════════════════════════════════════════════════════════════
 
@@ -557,19 +543,28 @@ sub_promote_learning() {
 }
 
 # ══════════════════════════════════════════════════════════════════
-# Subcommand: ingest-reviews (ADR-009 PR-G)
+# Subcommand: resume-paused (ADR-010)
 # ══════════════════════════════════════════════════════════════════
 
-sub_ingest_reviews() {
-  if [ -z "$OPT_INGEST_FEAT" ]; then
-    err "Usage: ingest-reviews <feat-id>"
+sub_resume_paused() {
+  if [ -z "$OPT_RESUME_FEAT" ]; then
+    err "Usage: ./scripts/orchestrate.sh --resume-paused <feat-id> [--ack]"
     exit 1
   fi
 
+  source "$LIB_DIR/util.sh"
   source "$LIB_DIR/config.sh"
+  source "$LIB_DIR/worktree.sh"
+  source "$LIB_DIR/memory.sh"
+  source "$LIB_DIR/display.sh"
+  source "$LIB_DIR/cost.sh"
+  source "$LIB_DIR/router.sh"
   source "$LIB_DIR/learning.sh"
-  source "$LIB_DIR/local_model.sh"
-  source "$LIB_DIR/ingest.sh"
+  source "$LIB_DIR/size_gate.sh"
+  source "$LIB_DIR/cycle_gate.sh"
+  [ -f "$LIB_DIR/local_model.sh" ] && source "$LIB_DIR/local_model.sh"
+  [ -f "$LIB_DIR/ingest.sh"      ] && source "$LIB_DIR/ingest.sh"
+  source "$LIB_DIR/runner.sh"
 
   local config_file="$OPT_CONFIG"
   if [ ! -f "$config_file" ]; then
@@ -579,16 +574,32 @@ sub_ingest_reviews() {
   fi
   load_config "$config_file" 2>/dev/null || true
 
-  if [ "${LOCAL_MODEL_ENABLED:-false}" != "true" ]; then
-    err "ingest-reviews requires local_model.enabled: true in config"
-    exit 1
+  WORKTREE_ROOT="$ROOT_DIR/$WORKTREE_BASE"
+  export ROOT_DIR CONFIG_DIR STATE_DIR RESULTS_DIR WORKTREE_ROOT
+  export WORKTREE_BASE BRANCH_PREFIX BASE_BRANCH ADAPTER AUTONOMY MODEL_DEFAULT MODEL_PLAN MODEL_EXECUTE
+  mkdir -p "$STATE_DIR" "$RESULTS_DIR"
+
+  banner "Resume Paused — $OPT_RESUME_FEAT"
+
+  local ack_flag=""
+  [ "$OPT_RESUME_ACK" = "true" ] && ack_flag="--ack"
+
+  run_feature_resume "$OPT_RESUME_FEAT" $ack_flag
+}
+
+# ══════════════════════════════════════════════════════════════════
+# Subcommand: ingest-status (ADR-009)
+# ══════════════════════════════════════════════════════════════════
+
+sub_ingest_status() {
+  [ -f "$LIB_DIR/ingest.sh" ] && source "$LIB_DIR/ingest.sh" || true
+
+  banner "Background Ingest Status"
+  if declare -f ingest_status &>/dev/null; then
+    ingest_status
+  else
+    info "ingest.sh not loaded — no background ingest infrastructure present."
   fi
-
-  # Run health check before ingesting
-  local_model_health_check || exit 1
-
-  banner "Review Ingest — $OPT_INGEST_FEAT"
-  ingest_reviews "$OPT_INGEST_FEAT"
 }
 
 # ══════════════════════════════════════════════════════════════════
@@ -596,13 +607,13 @@ sub_ingest_reviews() {
 # ══════════════════════════════════════════════════════════════════
 
 case "$SUBCOMMAND" in
-  init)             sub_init ;;
-  run)              sub_run ;;
-  status)           sub_status ;;
-  clean)            sub_clean ;;
-  clean-merged)     sub_clean_merged ;;
-  calibrate)        sub_calibrate ;;
-  learning)         sub_learning ;;
+  init)            sub_init ;;
+  run)             sub_run ;;
+  status)          sub_status ;;
+  clean)           sub_clean ;;
+  calibrate)       sub_calibrate ;;
+  learning)        sub_learning ;;
   promote-learning) sub_promote_learning ;;
-  ingest-reviews)   sub_ingest_reviews ;;
+  resume-paused)   sub_resume_paused ;;
+  ingest-status)   sub_ingest_status ;;
 esac

--- a/tests/lib/ingest.bats
+++ b/tests/lib/ingest.bats
@@ -1,0 +1,294 @@
+#!/usr/bin/env bats
+# tests/lib/ingest.bats
+#
+# Unit tests for scripts/lib/ingest.sh covering the two issues fixed in
+# feat/adr-010-skill-pluggability:
+#
+#   1. Collapsed pid-file reads  (ingest_reap_stale / ingest_status)
+#      — each pid file is now read with a single node call that returns
+#        pid, feat_id, and started_at tab-separated.
+#
+#   2. JS-interpolation removal  (all node -e/-p sites)
+#      — shell vars no longer appear inside JS string literals; values
+#        pass via process.argv instead.
+#
+# Prerequisites: bats-core >= 1.7, node >= 16 in PATH
+#
+# Run:
+#   bats tests/lib/ingest.bats
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+# Write a valid pid-file JSON for a given feat_id and pid.
+_write_pid_file() {
+  local pid_file="$1" pid="$2" feat_id="$3" started_at="${4:-2026-04-19T00:00:00.000Z}"
+  mkdir -p "$(dirname "$pid_file")"
+  printf '{"pid":%s,"feat_id":"%s","started_at":"%s"}\n' \
+    "$pid" "$feat_id" "$started_at" > "$pid_file"
+}
+
+# Write a minimal results.json with a pr_url.
+_write_results() {
+  local file="$1" pr_url="$2"
+  mkdir -p "$(dirname "$file")"
+  printf '{"pr_url":"%s"}\n' "$pr_url" > "$file"
+}
+
+# Source ingest.sh with the minimal environment it needs.
+_source_ingest() {
+  info()  { echo "[info] $*"; }
+  err()   { echo "[err] $*" >&2; }
+  export -f info err
+
+  export LOCAL_MODEL_ENABLED="${LOCAL_MODEL_ENABLED:-false}"
+  export INGEST_CONFIDENCE_THRESHOLD="${INGEST_CONFIDENCE_THRESHOLD:-0.7}"
+
+  # shellcheck source=scripts/lib/ingest.sh
+  source "$REPO_ROOT/scripts/lib/ingest.sh"
+}
+
+# ── setup / teardown ──────────────────────────────────────────────────
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  export STATE_DIR="$TEST_TMP/state"
+  export ROOT_DIR="$TEST_TMP"
+  mkdir -p "$STATE_DIR"
+
+  # Put stubs ahead of real binaries so gh/git are controlled;
+  # real node is used for all ingest calls (stub passes through argv-based calls).
+  export STUBS_DIR="$BATS_TEST_DIRNAME/../stubs"
+  export PATH="$STUBS_DIR:$PATH"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+  unset STATE_DIR ROOT_DIR LOCAL_MODEL_ENABLED INGEST_CONFIDENCE_THRESHOLD
+}
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. ingest_status — collapsed pid-file reads
+# ═══════════════════════════════════════════════════════════════════════
+
+@test "ingest_status: no state directory → reports no active jobs" {
+  rm -rf "$STATE_DIR"
+  _source_ingest
+
+  run ingest_status
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No state directory"* ]]
+}
+
+@test "ingest_status: no pid files → reports no active jobs" {
+  _source_ingest
+
+  run ingest_status
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No active background ingest jobs"* ]]
+}
+
+@test "ingest_status: pid file present — all three fields (pid, feat_id, started_at) appear in output" {
+  _write_pid_file "$STATE_DIR/my-feat/ingest.pid" 12345 "my-feat" "2026-04-19T10:00:00.000Z"
+  _source_ingest
+
+  run ingest_status
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"my-feat"* ]]
+  [[ "$output" == *"12345"* ]]
+  [[ "$output" == *"2026-04-19T10:00:00.000Z"* ]]
+}
+
+@test "ingest_status: process not running → shows zombie status" {
+  # PID 99999 is virtually guaranteed to not be a live process
+  _write_pid_file "$STATE_DIR/z-feat/ingest.pid" 99999 "z-feat"
+  _source_ingest
+
+  run ingest_status
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"zombie"* ]]
+}
+
+@test "ingest_status: corrupt pid file → returns 0 without crashing" {
+  mkdir -p "$STATE_DIR/bad-feat"
+  echo "not json at all" > "$STATE_DIR/bad-feat/ingest.pid"
+  _source_ingest
+
+  run ingest_status
+
+  [ "$status" -eq 0 ]
+}
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. ingest_reap_stale — collapsed pid-file reads + cleanup logic
+# ═══════════════════════════════════════════════════════════════════════
+
+@test "ingest_reap_stale: no state directory → returns 0" {
+  rm -rf "$STATE_DIR"
+  _source_ingest
+
+  run ingest_reap_stale
+
+  [ "$status" -eq 0 ]
+}
+
+@test "ingest_reap_stale: pid=0 in pid file → file removed immediately" {
+  local pid_file="$STATE_DIR/zero-feat/ingest.pid"
+  _write_pid_file "$pid_file" 0 "zero-feat"
+  _source_ingest
+
+  run ingest_reap_stale
+
+  [ "$status" -eq 0 ]
+  [ ! -f "$pid_file" ]
+}
+
+@test "ingest_reap_stale: dead pid → pid file removed and feat_id logged" {
+  local pid_file="$STATE_DIR/dead-feat/ingest.pid"
+  _write_pid_file "$pid_file" 99999 "dead-feat"
+  _source_ingest
+
+  run ingest_reap_stale
+
+  [ "$status" -eq 0 ]
+  [ ! -f "$pid_file" ]
+  [[ "$output" == *"dead-feat"* ]]
+}
+
+@test "ingest_reap_stale: live pid → pid file kept" {
+  # Use the current test process as a guaranteed live PID
+  local pid_file="$STATE_DIR/live-feat/ingest.pid"
+  _write_pid_file "$pid_file" $$ "live-feat"
+  _source_ingest
+
+  run ingest_reap_stale
+
+  [ "$status" -eq 0 ]
+  [ -f "$pid_file" ]
+}
+
+@test "ingest_reap_stale: corrupt pid file → returns 0 without crashing" {
+  mkdir -p "$STATE_DIR/corrupt-feat"
+  echo "{ bad json" > "$STATE_DIR/corrupt-feat/ingest.pid"
+  _source_ingest
+
+  run ingest_reap_stale
+
+  [ "$status" -eq 0 ]
+}
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. ingest_trigger_if_merged — injection safety (argv-based pid write)
+# ═══════════════════════════════════════════════════════════════════════
+
+@test "ingest_trigger_if_merged: pid file contains literal feat_id (no JS injection)" {
+  # feat_id with a single-quote would break the old interpolated pattern
+  local feat_id="it's-a-tricky-feat"
+  local results_file="$STATE_DIR/$feat_id/results.json"
+  _write_results "$results_file" "https://github.com/org/repo/pull/42"
+
+  export LOCAL_MODEL_ENABLED="true"
+  _source_ingest
+
+  # Run the function; it tries to background ingest_reviews which may not be
+  # available — that's fine, we only care about the pid file write.
+  ingest_trigger_if_merged "$feat_id" 2>/dev/null || true
+
+  local pid_file="$STATE_DIR/$feat_id/ingest.pid"
+  [ -f "$pid_file" ]
+
+  # The stored feat_id must be the literal string, not an execution artefact
+  local stored_feat_id
+  stored_feat_id=$(node -p "JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')).feat_id" "$pid_file")
+  [ "$stored_feat_id" = "$feat_id" ]
+}
+
+@test "ingest_trigger_if_merged: pid file contains numeric pid" {
+  local feat_id="numeric-pid-feat"
+  _write_results "$STATE_DIR/$feat_id/results.json" "https://github.com/org/repo/pull/1"
+
+  export LOCAL_MODEL_ENABLED="true"
+  _source_ingest
+
+  ingest_trigger_if_merged "$feat_id" 2>/dev/null || true
+
+  local pid_file="$STATE_DIR/$feat_id/ingest.pid"
+  [ -f "$pid_file" ]
+
+  local stored_pid
+  stored_pid=$(node -p "typeof JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')).pid" "$pid_file")
+  [ "$stored_pid" = "number" ]
+}
+
+@test "ingest_trigger_if_merged: returns 0 when LOCAL_MODEL_ENABLED is false" {
+  export LOCAL_MODEL_ENABLED="false"
+  _source_ingest
+
+  run ingest_trigger_if_merged "any-feat"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "ingest_trigger_if_merged: returns 0 when results.json absent" {
+  export LOCAL_MODEL_ENABLED="true"
+  _source_ingest
+
+  run ingest_trigger_if_merged "no-results-feat"
+
+  [ "$status" -eq 0 ]
+}
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. ingest_write_fixes — argv-based threshold + path passing
+# ═══════════════════════════════════════════════════════════════════════
+
+@test "ingest_write_fixes: writes fix above threshold to learned.json" {
+  export ROOT_DIR="$TEST_TMP"
+  local feat_id="threshold-feat"
+  export INGEST_CONFIDENCE_THRESHOLD="0.5"
+
+  local summarizer_json='{"confidence":0.9,"fixes":[{"pattern":"missing null check","fix":"add null guard","confidence":0.9}]}'
+
+  _source_ingest
+
+  run ingest_write_fixes "$feat_id" "$summarizer_json" "pr_review"
+
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]  # one fix written
+
+  local store="$TEST_TMP/.claude/feature-state/learned.json"
+  [ -f "$store" ]
+  local count
+  count=$(node -p "JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')).length" "$store")
+  [ "$count" -eq 1 ]
+}
+
+@test "ingest_write_fixes: skips fix below threshold and writes 0" {
+  export ROOT_DIR="$TEST_TMP"
+  local feat_id="low-conf-feat"
+  export INGEST_CONFIDENCE_THRESHOLD="0.8"
+
+  local summarizer_json='{"confidence":0.3,"fixes":[{"pattern":"low confidence fix","fix":"maybe do this","confidence":0.3}]}'
+
+  _source_ingest
+
+  run ingest_write_fixes "$feat_id" "$summarizer_json" "pr_review"
+
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 0 ]  # nothing written
+}
+
+@test "ingest_write_fixes: invalid JSON from summarizer → writes 0, does not crash" {
+  export ROOT_DIR="$TEST_TMP"
+  _source_ingest
+
+  run ingest_write_fixes "bad-json-feat" "not json" "ci_failure"
+
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 0 ]
+}

--- a/tests/stubs/node
+++ b/tests/stubs/node
@@ -9,7 +9,19 @@
 #
 # All other node invocations are passed to the real node binary if available.
 
-REAL_NODE="$(PATH=/usr/bin:/usr/local/bin:/opt/homebrew/bin which node 2>/dev/null || true)"
+# Find real node by checking known paths in priority order.
+# ${BASH_SOURCE[0]} resolves to the stub name (not full path) when invoked via PATH,
+# so path-subtraction approaches cause infinite recursion. Instead, check explicit
+# locations: NVM_BIN (set by nvm), homebrew, and system.
+REAL_NODE=""
+for _candidate in \
+    "${NVM_BIN:+$NVM_BIN/node}" \
+    /opt/homebrew/bin/node \
+    /usr/local/bin/node \
+    /usr/bin/node \
+    ; do
+  [[ -n "$_candidate" && -x "$_candidate" ]] && { REAL_NODE="$_candidate"; break; }
+done
 
 # node -e "...writeFileSync(...)..." — health file write
 if [[ "${1:-}" == "-e" && "${2:-}" == *"writeFileSync"* ]]; then
@@ -24,7 +36,9 @@ if [[ "${1:-}" == "-e" && "${2:-}" == *"writeFileSync"* ]]; then
 fi
 
 # node -p "...readFileSync(LOCAL_MODEL_HEALTH_FILE...)..." — reachability probe
-if [[ "${1:-}" == "-p" && "${2:-}" == *"readFileSync"* ]]; then
+# Only intercept old-style calls with no extra arguments (no process.argv[1]).
+# Argv-based calls (new ingest.sh pattern) have $3+ set — pass those to real node.
+if [[ "${1:-}" == "-p" && "${2:-}" == *"readFileSync"* && $# -le 2 ]]; then
   echo "${NODE_HEALTH_REACHABLE:-false}"
   exit 0
 fi


### PR DESCRIPTION
## Summary

- **Skill Registry** (`scripts/lib/skills.sh`): SKILL.md frontmatter discovery under `.claude/skills/`; `skill_invoke` wraps `claude --skill` with `op_timeout` and `fail_open`; `skill_invoke_hook` fan-out for hook taxonomy (`phase3.fix_hint`, `phase4_5.summarize`, `learning.curate`, `routing.suggest_agent`); `skills` subcommand lists registered skills
- **Hang fixes**: subshell-pipe bug in `runner.sh` main loop replaced with process substitution; `size_gate.sh` read gets `read -t 120` so unattended runs auto-decline; `op_timeout` portable wrapper in `util.sh`; `js_string` helper for safe JSON quoting
- **Pause taxonomy** (`pause_kind: human|transient`): every pause writes `pause.json`; `--resume-paused <feat-id> [--ack]` re-enters runner from checkpoint; `runner_clear_sentinels` resets transient sentinels on resume
- **Background ingest reaping** (`scripts/lib/ingest.sh`): `ingest_trigger_if_merged` writes PID file; `ingest_reap_stale` called at startup; `ingest-status` subcommand
- **Learning-curator skill** (`feature-marker-dist/.../learning-curator/SKILL.md`): first skill-registry consumer; hooks `phase4_5.summarize` + `learning.curate`; same JSON contract as `local_model::summarize`

## Scope

CLI orchestrator (`scripts/orchestrate.sh`, `scripts/lib/`) and one new skill under `feature-marker-dist/`. The `/feature-marker` skill is unchanged.

## Depends on

- ADR-008 (merged — PR #27): token-economy, router, learning store
- ADR-009 (PR #28, still open): `local_model.sh` + full `ingest.sh` — ADR-010 sources them conditionally, degrades gracefully when absent

## What changed from the audit

The audit found 8 confirmed stuck-state risks. All HIGH-severity issues are fixed in this PR:

| Issue                                                 | Fix                                          |
| ----------------------------------------------------- | -------------------------------------------- |
| `\| while` subshell pipe: break only exits subshell   | Process substitution `< <(...)` in runner.sh |
| Unbounded `read -p` in supervised mode                | `read -t 120` in size_gate.sh                |
| `--resume` parsed but never wired up                  | `--resume-paused <feat-id>` subcommand       |
| No PID tracking for background ingest                 | PID file + `ingest_reap_stale` in ingest.sh  |
| `claude --skill` invocation untimed                   | `skill_invoke` wraps with `op_timeout`       |
| `gh` CLI calls untimed                                | `op_timeout` available for all callers       |
| Sentinel files survive across runs silently           | `runner_clear_sentinels` on resume           |
| JSON injection via `node -p "JSON.stringify('$var')"` | `js_string` helper in util.sh                |

## Test plan

- [ ] `bash -n scripts/lib/util.sh scripts/lib/skills.sh scripts/lib/ingest.sh scripts/lib/runner.sh scripts/lib/size_gate.sh scripts/orchestrate.sh` — all syntax clean
- [ ] `./scripts/orchestrate.sh --help` — shows `--resume-paused`, `--rescan-skills`, `skills`, `ingest-status`
- [ ] `./scripts/orchestrate.sh skills` — "No skills registered" (empty registry)
- [ ] Drop a test SKILL.md under `.claude/skills/test-skill/`, run `./scripts/orchestrate.sh --rescan-skills skills` — skill appears in list
- [ ] Run a feature in supervised mode, decline size-gate prompt — `pause.json` records `pause_kind:"human"`; re-run → feature skipped; `--resume-paused <id> --ack` → feature resumes
- [ ] Run with no operator at terminal in supervised mode — size-gate prompt times out at 120s, records `action:"timeout_skipped"`
- [ ] Subshell fix: synthetic backlog of 3 items where item 1 triggers a `break` — runner stops at item 1 (previously continued to items 2-3)
- [ ] `./scripts/orchestrate.sh ingest-status` — "No active background ingest jobs"
- [ ] `./scripts/orchestrate.sh run` with ADR-009 absent — no error (conditional source)
