### PR TITLE
feat: add --verbose flag and remove hardcoded [DEBUG] log

### DIFF
--- a/scripts/lib/local_model.sh
+++ b/scripts/lib/local_model.sh
@@ -89,7 +89,7 @@ local_model_health_check() {
   " 2>/dev/null || true
 
   if [ "$reachable" = "true" ]; then
-    info "Local model: ${LOCAL_MODEL_PROVIDER} reachable at ${LOCAL_MODEL_ENDPOINT} [DEBUG]"
+    [ "${VERBOSE:-}" = "true" ] && info "Local model: ${LOCAL_MODEL_PROVIDER} reachable at ${LOCAL_MODEL_ENDPOINT}"
     return 0
   fi
 

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -19,6 +19,7 @@
 #   --config <path>      Config file (default: orchestrator/config.yml)
 #   --plan               Show the plan, don't execute
 #   --dry-run             Alias for --plan
+#   -v, --verbose        Enable verbose output
 #   --help               Show this help
 
 set -euo pipefail
@@ -83,6 +84,7 @@ OPT_LEARNING_ACTION=""
 OPT_LEARNING_ID=""
 OPT_LEARNING_CANDIDATES=false
 OPT_INGEST_FEAT=""
+VERBOSE=false
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -106,6 +108,9 @@ while [ $# -gt 0 ]; do
       ;;
     --plan|--dry-run)
       OPT_DRY_RUN=true
+      ;;
+    -v|--verbose)
+      VERBOSE=true
       ;;
     --resume)
       OPT_RESUME=true
@@ -149,6 +154,7 @@ while [ $# -gt 0 ]; do
       echo "  --resume                   Skip completed, run pending"
       echo "  --skip-cycle-check         Skip the cycle-completion gate"
       echo "  --sample <n>               Sample size for calibrate (default: 10)"
+      echo "  -v, --verbose              Enable verbose output"
       echo "  --help                     Show this help"
       exit 0
       ;;
@@ -173,6 +179,7 @@ while [ $# -gt 0 ]; do
 done
 
 export OPT_SKIP_CYCLE_CHECK
+export VERBOSE
 
 [ -z "$SUBCOMMAND" ] && { err "No command given. Run: ./scripts/orchestrate.sh --help"; exit 1; }
 

--- a/tests/lib/verbose_flag.bats
+++ b/tests/lib/verbose_flag.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# tests/lib/verbose_flag.bats
+#
+# Unit tests for the --verbose / -v flag added in feat/verbose-flag:
+#
+#   1. orchestrate.sh flag parsing (subprocess tests)
+#      - --help output mentions -v, --verbose
+#      - -v before the subcommand is accepted (flag before subcommand)
+#      - unknown subcommand still shows usage
+#
+#   2. local_model.sh debug-output gating
+#      - VERBOSE=false → debug message absent from output
+#      - VERBOSE=true  → debug message present in output
+#
+# Prerequisites: bats-core >= 1.7
+#
+# Run:
+#   bats tests/lib/verbose_flag.bats
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  export STUBS_DIR="$BATS_TEST_DIRNAME/../stubs"
+
+  # Stubs ahead of real binaries
+  export PATH="$STUBS_DIR:$PATH"
+
+  # Needed by local_model.sh defaults
+  export STATE_DIR="$TEST_TMP/state"
+  mkdir -p "$STATE_DIR"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+  unset CURL_STUB_MODE NODE_HEALTH_REACHABLE VERBOSE \
+        CFG_LOCAL_MODEL_ENABLED CFG_LOCAL_MODEL_PROVIDER CFG_LOCAL_MODEL_ENDPOINT \
+        LOCAL_MODEL_ENABLED LOCAL_MODEL_PROVIDER LOCAL_MODEL_ENDPOINT \
+        LOCAL_MODEL_HEALTH_FILE
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# 1. orchestrate.sh flag parsing (subprocess)
+# ═══════════════════════════════════════════════════════════════════
+
+@test "orchestrate.sh --help lists -v, --verbose flag" {
+  # Run from the repo root so git rev-parse succeeds
+  run bash -c "cd '$REPO_ROOT' && bash scripts/orchestrate.sh --help"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-v, --verbose"* ]]
+}
+
+@test "orchestrate.sh -v --help is accepted (verbose flag before subcommand)" {
+  # -v before --help should not cause an error; help should still print
+  run bash -c "cd '$REPO_ROOT' && bash scripts/orchestrate.sh -v --help"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-v, --verbose"* ]]
+}
+
+@test "orchestrate.sh with unknown subcommand prints usage hint and exits non-zero" {
+  run bash -c "cd '$REPO_ROOT' && bash scripts/orchestrate.sh not-a-real-subcommand 2>&1"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--help"* ]]
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# 2. local_model.sh debug-output gating
+# ═══════════════════════════════════════════════════════════════════
+
+# Helper: define the log helpers that local_model.sh expects from its caller,
+# then source the library under test.
+_source_local_model() {
+  # Minimal stand-ins for the orchestrate.sh log helpers
+  info() { echo "  [orchestrate] $*"; }
+  err()  { echo "✗ [orchestrate] $*" >&2; }
+  export -f info err
+
+  # Put the health file somewhere writable
+  export LOCAL_MODEL_HEALTH_FILE="$STATE_DIR/local_model_health.json"
+
+  # shellcheck source=scripts/lib/local_model.sh
+  source "$REPO_ROOT/scripts/lib/local_model.sh"
+}
+
+@test "local_model_health_check: debug message absent when VERBOSE=false (default)" {
+  export CURL_STUB_MODE="reachable"
+  # Use CFG_ vars so local_model.sh initialisation picks them up at source time
+  export CFG_LOCAL_MODEL_ENABLED="true"
+  export CFG_LOCAL_MODEL_PROVIDER="ollama"
+  export CFG_LOCAL_MODEL_ENDPOINT="http://localhost:11434"
+  export VERBOSE="false"
+
+  _source_local_model
+
+  run local_model_health_check
+
+  [ "$status" -eq 0 ]
+  # The debug "reachable at" message must NOT appear when VERBOSE is false
+  [[ "$output" != *"reachable at"* ]]
+}
+
+@test "local_model_health_check: debug message present when VERBOSE=true" {
+  export CURL_STUB_MODE="reachable"
+  # Use CFG_ vars so local_model.sh initialisation picks them up at source time
+  export CFG_LOCAL_MODEL_ENABLED="true"
+  export CFG_LOCAL_MODEL_PROVIDER="ollama"
+  export CFG_LOCAL_MODEL_ENDPOINT="http://localhost:11434"
+  export VERBOSE="true"
+
+  _source_local_model
+
+  run local_model_health_check
+
+  [ "$status" -eq 0 ]
+  # The info message must appear when VERBOSE=true and the endpoint is reachable
+  [[ "$output" == *"reachable at"* ]]
+  [[ "$output" == *"ollama"* ]]
+}
+
+@test "local_model_health_check: disabled — returns 0 and no debug output regardless of VERBOSE" {
+  export CFG_LOCAL_MODEL_ENABLED="false"
+  export VERBOSE="true"
+
+  _source_local_model
+
+  run local_model_health_check
+
+  [ "$status" -eq 0 ]
+  # When disabled the function returns immediately; no reachable message
+  [[ "$output" != *"reachable at"* ]]
+}

--- a/tests/lib/worktree_cleanup_merged.bats
+++ b/tests/lib/worktree_cleanup_merged.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# tests/lib/worktree_cleanup_merged.bats
+#
+# Unit tests for wt_cleanup_merged() in scripts/lib/worktree.sh.
+#
+# Prerequisites: bats-core >= 1.7
+#   brew install bats-core       # macOS
+#   apt-get install bats         # Ubuntu/Debian
+#
+# Run:
+#   bats tests/lib/worktree_cleanup_merged.bats
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup() {
+  # Isolated temp environment for each test
+  TEST_TMP="$(mktemp -d)"
+  export WORKTREE_ROOT="$TEST_TMP/worktrees"
+  export STATE_DIR="$TEST_TMP/state"
+  export RESULTS_DIR="$TEST_TMP/results"
+  export ROOT_DIR="$TEST_TMP"
+  export BASE_BRANCH="main"
+  export BRANCH_PREFIX="feat"
+  mkdir -p "$WORKTREE_ROOT" "$STATE_DIR" "$RESULTS_DIR"
+
+  # Put stubs ahead of real binaries on PATH
+  export STUBS_DIR="$BATS_TEST_DIRNAME/../stubs"
+  export PATH="$STUBS_DIR:$PATH"
+
+  # Source the library under test
+  # shellcheck source=scripts/lib/worktree.sh
+  source "$REPO_ROOT/scripts/lib/worktree.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+  unset GH_STUB_MODE GH_MERGED_BRANCHES GIT_WORKTREE_STUB
+}
+
+# ── gh CLI not installed ───────────────────────────────────────
+
+@test "warns and returns 0 when gh CLI is not installed" {
+  # Use a minimal PATH containing only core system dirs so that gh (installed
+  # via Homebrew or elsewhere) is not found and command -v gh returns non-zero.
+  local saved_path="$PATH"
+  export PATH="/usr/bin:/bin"
+
+  run wt_cleanup_merged "main"
+
+  export PATH="$saved_path"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gh CLI not found"* ]]
+}
+
+# ── gh not authenticated ───────────────────────────────────────
+
+@test "warns and returns 0 when gh is not authenticated" {
+  export GH_STUB_MODE="auth_fail"
+
+  run wt_cleanup_merged "main"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Not authenticated"* ]]
+}
+
+# ── GitHub query failures ──────────────────────────────────────
+
+@test "warns and returns 0 when GitHub API query fails" {
+  export GH_STUB_MODE="fail_query"
+
+  run wt_cleanup_merged "main"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Could not query GitHub"* ]]
+}
+
+# ── No merged branches ────────────────────────────────────────
+
+@test "reports no branches and returns 0 when no merged feat/* PRs exist" {
+  export GH_STUB_MODE="no_prs"
+
+  run wt_cleanup_merged "main"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No merged feat/* branches found"* ]]
+}
+
+# ── Merged branch, no local worktree ──────────────────────────
+
+@test "reports nothing to clean when merged branch has no local worktree" {
+  export GH_STUB_MODE="has_merged"
+  export GH_MERGED_BRANCHES="feat/feat-001"
+  export GIT_WORKTREE_STUB=""  # git worktree list returns nothing
+
+  run wt_cleanup_merged "main"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No local worktrees found"* ]]
+}
+
+# ── Merged branch, worktree exists ────────────────────────────
+
+@test "removes worktree and reports cleaned when merged branch has a local worktree" {
+  export GH_STUB_MODE="has_merged"
+  export GH_MERGED_BRANCHES="feat/feat-001"
+
+  # Create the worktree directory so wt_remove has something to remove
+  mkdir -p "$WORKTREE_ROOT/feat-001"
+  export GIT_WORKTREE_STUB="has:$WORKTREE_ROOT/feat-001"
+
+  run wt_cleanup_merged "main"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ Cleaned"* ]]
+  [[ "$output" == *"feat-001"* ]]
+  # Directory should be gone
+  [ ! -d "$WORKTREE_ROOT/feat-001" ]
+}
+
+@test "removes multiple worktrees when several merged branches have local worktrees" {
+  export GH_STUB_MODE="has_merged"
+  export GH_MERGED_BRANCHES="$(printf 'feat/feat-001\nfeat/feat-002')"
+
+  mkdir -p "$WORKTREE_ROOT/feat-001" "$WORKTREE_ROOT/feat-002"
+  # git worktree list stub needs to match both paths; we return both on separate lines
+  # Use the first one — the function checks each path individually so stub returning
+  # either path is sufficient to exercise the removal logic per-branch
+  export GIT_WORKTREE_STUB="has:$WORKTREE_ROOT/feat-001"
+
+  run wt_cleanup_merged "main"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"feat-001"* ]]
+}
+
+@test "logs are copied to results before worktree is removed" {
+  export GH_STUB_MODE="has_merged"
+  export GH_MERGED_BRANCHES="feat/feat-001"
+
+  mkdir -p "$WORKTREE_ROOT/feat-001" "$STATE_DIR/feat-001/logs"
+  echo "test log" > "$STATE_DIR/feat-001/logs/run.log"
+  export GIT_WORKTREE_STUB="has:$WORKTREE_ROOT/feat-001"
+
+  run wt_cleanup_merged "main"
+
+  [ "$status" -eq 0 ]
+  [ -f "$RESULTS_DIR/run.log" ]
+}
+
+# ── BRANCH_PREFIX customisation ───────────────────────────────
+
+@test "respects a custom BRANCH_PREFIX" {
+  export BRANCH_PREFIX="feature"
+  export GH_STUB_MODE="has_merged"
+  export GH_MERGED_BRANCHES="feature/feat-003"
+
+  mkdir -p "$WORKTREE_ROOT/feat-003"
+  export GIT_WORKTREE_STUB="has:$WORKTREE_ROOT/feat-003"
+
+  run wt_cleanup_merged "main"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"feat-003"* ]]
+}

--- a/tests/stubs/curl
+++ b/tests/stubs/curl
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Stub for curl used in local_model_health_check tests.
+#
+# Mimics: curl -s -o <file> -w "%{http_code}" --max-time <n> <url>
+#
+# Behavior is controlled by CURL_STUB_MODE:
+#   reachable   — writes minimal JSON to the -o file, prints "200" (the http_code)
+#   unreachable — prints "000" (the http_code); -o file gets empty content
+#   (default)   — unreachable
+
+OUTPUT_FILE=""
+
+# Walk all args to find -o <file>
+args=("$@")
+i=0
+while [ $i -lt ${#args[@]} ]; do
+  if [[ "${args[$i]}" == "-o" ]]; then
+    i=$((i + 1))
+    OUTPUT_FILE="${args[$i]}"
+  fi
+  i=$((i + 1))
+done
+
+case "${CURL_STUB_MODE:-unreachable}" in
+  reachable)
+    [ -n "$OUTPUT_FILE" ] && echo '{"models":[]}' > "$OUTPUT_FILE"
+    printf "200"
+    ;;
+  *)
+    [ -n "$OUTPUT_FILE" ] && printf '' > "$OUTPUT_FILE"
+    printf "000"
+    ;;
+esac

--- a/tests/stubs/gh
+++ b/tests/stubs/gh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Stub for the gh CLI used in tests.
+#
+# Behavior is controlled by GH_STUB_MODE:
+#   auth_fail   — gh auth status exits 1 (not authenticated)
+#   no_prs      — pr list returns empty (no merged branches)
+#   has_merged  — pr list returns GH_MERGED_BRANCHES (newline-separated)
+#   fail_query  — auth passes but pr list exits 1 (network/API error)
+#   (default)   — auth passes, pr list returns empty
+
+ARGS="$*"
+
+case "${GH_STUB_MODE:-}" in
+  auth_fail)
+    if [[ "$ARGS" == *"auth status"* ]]; then exit 1; fi
+    exit 0
+    ;;
+  no_prs)
+    if [[ "$ARGS" == *"auth status"* ]]; then exit 0; fi
+    if [[ "$ARGS" == *"pr list"* ]];    then printf ''; exit 0; fi
+    exit 0
+    ;;
+  has_merged)
+    if [[ "$ARGS" == *"auth status"* ]]; then exit 0; fi
+    if [[ "$ARGS" == *"pr list"* ]]; then
+      printf '%s\n' "${GH_MERGED_BRANCHES:-}"
+      exit 0
+    fi
+    exit 0
+    ;;
+  fail_query)
+    if [[ "$ARGS" == *"auth status"* ]]; then exit 0; fi
+    if [[ "$ARGS" == *"pr list"* ]];    then exit 1; fi
+    exit 0
+    ;;
+  *)
+    if [[ "$ARGS" == *"auth status"* ]]; then exit 0; fi
+    exit 0
+    ;;
+esac

--- a/tests/stubs/git
+++ b/tests/stubs/git
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Stub for git — intercepts worktree subcommands used by wt_cleanup_merged.
+# All other git commands are passed through to the real git binary.
+#
+# GIT_WORKTREE_STUB controls worktree list output:
+#   (empty / unset) — worktree list prints nothing (no matching worktree)
+#   has:<path>      — worktree list prints <path> (simulates a live worktree)
+
+REAL_GIT="/usr/bin/git"
+
+# Intercept: git worktree list
+if [[ "${1:-}" == "worktree" && "${2:-}" == "list" ]]; then
+  case "${GIT_WORKTREE_STUB:-}" in
+    has:*)
+      echo "${GIT_WORKTREE_STUB#has:}"
+      ;;
+    *)
+      : # empty output — no worktrees
+      ;;
+  esac
+  exit 0
+fi
+
+# Intercept: git worktree remove [--force] <path>
+# The path argument may appear before or after --force, so find it by
+# looking for the first argument that starts with / or .
+if [[ "${1:-}" == "worktree" && "${2:-}" == "remove" ]]; then
+  for arg in "${@:3}"; do
+    if [[ "$arg" == /* || "$arg" == ./* ]]; then
+      rm -rf "$arg" 2>/dev/null || true
+      break
+    fi
+  done
+  exit 0
+fi
+
+# Intercept: git worktree prune
+if [[ "${1:-}" == "worktree" && "${2:-}" == "prune" ]]; then
+  exit 0
+fi
+
+# Intercept: git -C <path> rev-parse --abbrev-ref HEAD  (used by wt_remove)
+if [[ "${1:-}" == "-C" && "${4:-}" == "--abbrev-ref" ]]; then
+  # Derive branch name from directory name: .worktrees/feat-001 -> feat/feat-001
+  local_dir="$(basename "${2:-unknown}")"
+  echo "feat/$local_dir"
+  exit 0
+fi
+
+# Intercept: git branch -D <branch>  (used by wt_remove)
+if [[ "${1:-}" == "branch" && "${2:-}" == "-D" ]]; then
+  exit 0
+fi
+
+# Pass everything else to the real git
+exec "$REAL_GIT" "$@"

--- a/tests/stubs/node
+++ b/tests/stubs/node
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Stub for node used in local_model_health_check tests.
+#
+# Supports only the subset of node calls made by local_model_health_check:
+#   node -e "...fs.writeFileSync(path, ...)"  — writes a minimal JSON file
+#   node -p "..."                              — used by _local_model_is_reachable;
+#                                               returns "false" by default,
+#                                               controlled by NODE_HEALTH_REACHABLE.
+#
+# All other node invocations are passed to the real node binary if available.
+
+REAL_NODE="$(PATH=/usr/bin:/usr/local/bin:/opt/homebrew/bin which node 2>/dev/null || true)"
+
+# node -e "...writeFileSync(...)..." — health file write
+if [[ "${1:-}" == "-e" && "${2:-}" == *"writeFileSync"* ]]; then
+  # Extract the file path from the script: writeFileSync('<path>', ...)
+  # The path is embedded as a shell-expanded variable in the -e string.
+  # We just need the side-effect to succeed; parse out the first string arg.
+  # Rather than fully parsing JS, delegate to real node if available, else no-op.
+  if [ -n "$REAL_NODE" ]; then
+    exec "$REAL_NODE" "$@"
+  fi
+  exit 0
+fi
+
+# node -p "...readFileSync(LOCAL_MODEL_HEALTH_FILE...)..." — reachability probe
+if [[ "${1:-}" == "-p" && "${2:-}" == *"readFileSync"* ]]; then
+  echo "${NODE_HEALTH_REACHABLE:-false}"
+  exit 0
+fi
+
+# Pass everything else to real node
+if [ -n "$REAL_NODE" ]; then
+  exec "$REAL_NODE" "$@"
+fi
+
+# No real node available — return empty
+exit 0


### PR DESCRIPTION
## Summary

- **Remove accidental `[DEBUG]` log** in `scripts/lib/local_model.sh` (line 92): the health-check success message was tagged with `[DEBUG]` and printed unconditionally on every `run`, polluting normal output.
- **Add `-v` / `--verbose` global flag** to `scripts/orchestrate.sh`: when passed, `VERBOSE=true` is exported so lib scripts can gate noisy diagnostic output behind it. The local model reachability message is now gated this way.

## How to use `--verbose`

Pass `-v` or `--verbose` before or alongside any subcommand:

```bash
./scripts/orchestrate.sh -v run
./scripts/orchestrate.sh --verbose run --dry-run
```

When `VERBOSE=true`, the local model health-check will print:
```
  [orchestrate] Local model: ollama reachable at http://localhost:11434
```
Without the flag, the message is suppressed (normal operation is unaffected).

## How to test

1. **Debug log is gone from normal output**
   ```bash
   ./scripts/orchestrate.sh run --dry-run 2>&1 | grep '\[DEBUG\]'
   # → no output
   ```

2. **Verbose flag surfaces the message**
   ```bash
   ./scripts/orchestrate.sh -v run --dry-run 2>&1 | grep 'reachable'
   # → "  [orchestrate] Local model: ollama reachable at …"  (only if local model is up)
   ```

3. **Help text shows the new flag**
   ```bash
   ./scripts/orchestrate.sh --help | grep verbose
   # → "  -v, --verbose              Enable verbose output"
   ```