### PR TITLE
feat: auto-update global-context.md after each feature completes

### DIFF
--- a/scripts/lib/learning.sh
+++ b/scripts/lib/learning.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # lib/learning.sh — Layered error learning store (ADR-008 PR-C, ADR-009 PR-F)
+#                   + global-context.md summary entries (ADR-010)
 #
 # 3-tier store:
 #   feature : $STATE_DIR/{feat_id}/learned.json
@@ -507,4 +508,75 @@ learning_promote() {
     fs.writeFileSync('$global_path', JSON.stringify(global, null, 2));
     console.log('  Promoted to global: $learn_id');
   " 2>/dev/null || true
+}
+
+# ── gc_append_feature_summary ─────────────────────────────────────────
+# Usage: gc_append_feature_summary <feat_id> <branch> <status> <pr_url>
+#
+# Appends a compact summary entry to .orchestrator/global-context.md
+# after a feature reaches "done" or "pr-created".
+#
+# The entry includes: feature ID, branch, timestamp, status, cost stats,
+# and PR URL (if available).
+#
+# Idempotent: if a heading for <feat_id> already exists, the entry is
+# skipped so re-runs don't duplicate content.
+
+gc_append_feature_summary() {
+  local feat_id="$1"
+  local branch="$2"
+  local status="$3"
+  local pr_url="${4:-}"
+
+  local gc_file="${CONTEXT_DIR:-$ROOT_DIR/.orchestrator}/global-context.md"
+
+  # Ensure the file exists with a header
+  if [ ! -f "$gc_file" ]; then
+    mkdir -p "$(dirname "$gc_file")"
+    cat > "$gc_file" <<'EOHDR'
+# Global Orchestration Context
+
+Accumulated feature summaries written after each successful run.
+Each entry is appended once (idempotent). Use this file to carry
+learnings across orchestration sessions.
+
+EOHDR
+  fi
+
+  # Idempotency: skip if a heading for this feature already exists
+  if grep -qF "## $feat_id " "$gc_file" 2>/dev/null; then
+    return 0
+  fi
+
+  # Collect cost stats from cost.json (if available)
+  local cost_file="$STATE_DIR/$feat_id/cost.json"
+  local cost_line=""
+  if [ -f "$cost_file" ]; then
+    local tokens
+    tokens=$(node -p "
+      try {
+        const d = JSON.parse(require('fs').readFileSync('$cost_file','utf-8'));
+        d.cumulative_tokens || 0;
+      } catch(e) { 0; }
+    " 2>/dev/null || echo "0")
+    if [ "$tokens" -gt 0 ] 2>/dev/null; then
+      cost_line="- Cost: ~${tokens} tokens"
+    fi
+  fi
+
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  {
+    echo ""
+    echo "## $feat_id — $ts"
+    echo "- Branch: $branch"
+    echo "- Status: $status"
+    [ -n "$cost_line" ] && echo "$cost_line"
+    if [ -n "$pr_url" ]; then
+      echo "- PR: $pr_url"
+    else
+      echo "- Outcome: completed successfully"
+    fi
+  } >> "$gc_file"
 }

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -479,6 +479,19 @@ EOPRD
   mem_record_context "$feat_id" "$title" "$priority" "$labels" "$wt_path" "$results_file"
   mem_refresh_env
 
+  # Auto-update global-context.md with a compact summary entry
+  local final_status
+  final_status=$(wt_get_status "$feat_id")
+  if [ "$final_status" = "done" ] || [ "$final_status" = "pr-created" ]; then
+    local final_pr_url=""
+    [ -f "$results_file" ] && final_pr_url=$(node -p "
+      try { JSON.parse(require('fs').readFileSync('$results_file','utf-8')).pr_url || ''; }
+      catch(e) { ''; }
+    " 2>/dev/null || echo "")
+    local final_branch="${BRANCH_PREFIX:-feat}/$feat_id"
+    gc_append_feature_summary "$feat_id" "$final_branch" "$final_status" "$final_pr_url"
+  fi
+
   info "Feature time: ${duration}s"
   echo ""
 }

--- a/tests/lib/global_context.bats
+++ b/tests/lib/global_context.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# tests/lib/global_context.bats
+#
+# Unit tests for gc_append_feature_summary() in scripts/lib/learning.sh.
+#
+# Prerequisites: bats-core >= 1.7
+#   brew install bats-core       # macOS
+#   apt-get install bats         # Ubuntu/Debian
+#
+# Run:
+#   bats tests/lib/global_context.bats
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup() {
+  # Isolated temp environment for each test
+  TEST_TMP="$(mktemp -d)"
+  export STATE_DIR="$TEST_TMP/state"
+  export ROOT_DIR="$TEST_TMP"
+  export CONTEXT_DIR="$TEST_TMP/.orchestrator"
+  mkdir -p "$STATE_DIR"
+
+  # Source the library under test; stub out functions that gc_append_feature_summary
+  # does NOT use (info, err) so that sourcing the file doesn't fail if display.sh
+  # isn't on the path.
+  info()  { :; }
+  err()   { :; }
+  export -f info err
+
+  # shellcheck source=scripts/lib/learning.sh
+  source "$REPO_ROOT/scripts/lib/learning.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+# ── File creation ─────────────────────────────────────────────────────
+
+@test "creates global-context.md with a header when the file does not exist" {
+  run gc_append_feature_summary "feat-001" "feat/my-feature" "done" ""
+
+  [ "$status" -eq 0 ]
+  local gc_file="$CONTEXT_DIR/global-context.md"
+  [ -f "$gc_file" ]
+  grep -q "# Global Orchestration Context" "$gc_file"
+}
+
+# ── Entry appended ────────────────────────────────────────────────────
+
+@test "appends feat_id to the file after calling the function" {
+  run gc_append_feature_summary "feat-001" "feat/my-feature" "done" ""
+
+  [ "$status" -eq 0 ]
+  local gc_file="$CONTEXT_DIR/global-context.md"
+  grep -q "feat-001" "$gc_file"
+}
+
+@test "appended entry contains branch name" {
+  run gc_append_feature_summary "feat-001" "feat/my-feature" "done" ""
+
+  [ "$status" -eq 0 ]
+  local gc_file="$CONTEXT_DIR/global-context.md"
+  grep -q "feat/my-feature" "$gc_file"
+}
+
+@test "appended entry contains status" {
+  run gc_append_feature_summary "feat-001" "feat/my-feature" "pr-created" ""
+
+  [ "$status" -eq 0 ]
+  local gc_file="$CONTEXT_DIR/global-context.md"
+  grep -q "pr-created" "$gc_file"
+}
+
+# ── Idempotency ───────────────────────────────────────────────────────
+
+@test "calling the function twice with the same feat_id does not duplicate the entry" {
+  gc_append_feature_summary "feat-001" "feat/my-feature" "done" ""
+  gc_append_feature_summary "feat-001" "feat/my-feature" "done" ""
+
+  local gc_file="$CONTEXT_DIR/global-context.md"
+  local count
+  count=$(grep -c "## feat-001 " "$gc_file")
+  [ "$count" -eq 1 ]
+}
+
+# ── Cost included when available ──────────────────────────────────────
+
+@test "includes cost line when cost.json exists with cumulative_tokens" {
+  mkdir -p "$STATE_DIR/feat-002"
+  echo '{"cumulative_tokens": 42000}' > "$STATE_DIR/feat-002/cost.json"
+
+  run gc_append_feature_summary "feat-002" "feat/costly-feature" "done" ""
+
+  [ "$status" -eq 0 ]
+  local gc_file="$CONTEXT_DIR/global-context.md"
+  grep -q "42000 tokens" "$gc_file"
+}
+
+# ── Cost omitted when missing ─────────────────────────────────────────
+
+@test "still writes the entry when cost.json does not exist" {
+  run gc_append_feature_summary "feat-003" "feat/cheap-feature" "done" ""
+
+  [ "$status" -eq 0 ]
+  local gc_file="$CONTEXT_DIR/global-context.md"
+  grep -q "feat-003" "$gc_file"
+}
+
+@test "does not include a cost line when cost.json is absent" {
+  run gc_append_feature_summary "feat-003" "feat/cheap-feature" "done" ""
+
+  [ "$status" -eq 0 ]
+  local gc_file="$CONTEXT_DIR/global-context.md"
+  # Should not have a cost line
+  run grep "Cost:" "$gc_file"
+  [ "$status" -ne 0 ]
+}
+
+# ── PR URL included ───────────────────────────────────────────────────
+
+@test "includes PR URL in entry when pr_url argument is provided" {
+  run gc_append_feature_summary "feat-004" "feat/pr-feature" "pr-created" \
+    "https://github.com/org/repo/pull/99"
+
+  [ "$status" -eq 0 ]
+  local gc_file="$CONTEXT_DIR/global-context.md"
+  grep -q "https://github.com/org/repo/pull/99" "$gc_file"
+}
+
+# ── PR URL omitted gracefully ─────────────────────────────────────────
+
+@test "writes completed-successfully outcome when pr_url is empty" {
+  run gc_append_feature_summary "feat-005" "feat/no-pr-feature" "done" ""
+
+  [ "$status" -eq 0 ]
+  local gc_file="$CONTEXT_DIR/global-context.md"
+  grep -q "completed successfully" "$gc_file"
+}


### PR DESCRIPTION
## Problem

`global-context.md` was only updated with low-level file/schema change records from `mem_record_context()`. There was no persistent, scannable log of which features completed, their final status, cost stats, or PR URLs. Each orchestration run started with no structured summary of prior outcomes, making it hard to reason about completed work across sessions.

## Solution

Add `gc_append_feature_summary()` to `scripts/lib/learning.sh` and call it from `scripts/lib/runner.sh` immediately after `mem_record_context`.

### What gets written

Each completed feature (status `done` or `pr-created`) appends one entry to `.orchestrator/global-context.md`:

```markdown
## feat-001 — 2024-01-15T10:30:00Z
- Branch: feat/feat-001
- Status: pr-created
- Cost: ~50000 tokens
- PR: https://github.com/owner/repo/pull/42
```

If no PR exists the last line reads `- Outcome: completed successfully`.

### How it hooks in

- `gc_append_feature_summary()` is added to `learning.sh` (already sourced on every `run`)
- Called at the end of `run_feature()` in `runner.sh`, after `cost_summary` and `mem_record_context`, so all state (status, cost.json, results.json) is already finalised
- If `global-context.md` does not yet exist it is created with a descriptive header

### Idempotency guarantee

Before appending, the function greps for a `## <feat_id> ` heading. If found, it returns immediately — re-running the orchestrator against the same completed feature never duplicates an entry.

## How to observe it

1. Run the orchestrator normally: `feature-marker-orchestrate run`
2. After any feature completes, inspect `.orchestrator/global-context.md`
3. Each completed feature appears once with its timestamp, status, token cost, and PR link
4. Running again with `--resume` leaves existing entries untouched (idempotency check passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)