### PR TITLE
chore: release v7.5.0 — update Homebrew formula

### DIFF
--- a/homebrew/feature-marker.rb
+++ b/homebrew/feature-marker.rb
@@ -6,9 +6,9 @@
 class FeatureMarker < Formula
   desc "AI-powered feature development automation — skill + orchestrator"
   homepage "https://github.com/Viniciuscarvalho/Feature-marker"
-  url "https://github.com/Viniciuscarvalho/Feature-marker/archive/18384ccc0b730367607768f1c7f9b915555a0613.tar.gz"
-  sha256 "9280014a521512a9b1fd38c6554d301b1692d18a0248ef8af4ad54d28cef0945"
-  version "7.4.0"
+  url "https://github.com/Viniciuscarvalho/Feature-marker/archive/refs/tags/v7.5.0.tar.gz"
+  sha256 "54ff0cc2294c0d7dbfa2e844cf591cf38513ae23259a27dbcf56a0abfcc4eebd"
+  version "7.5.0"
   license "MIT"
   head "https://github.com/Viniciuscarvalho/Feature-marker.git", branch: "main"
 


### PR DESCRIPTION
## What's New in v7.5.0

### Features

- **ADR-010: Skill pluggability** — stuck-state elimination, dropped bash skill registry in favour of a cleaner plug-in model (#29)
- **ADR-009: Local-model integration** — embedding, classifier, summarizer and generator pipeline (PR-E through PR-H) (#28)
- **ADR-008: Orchestrator token-economy** — block-based architecture with cost gates, cycle gates, size gates and router (#27)
- **Model selection** — plan phase runs on Opus, execute phase runs on Sonnet for optimal cost/quality (#24)
- **`--verbose` / `-v` flag** — replaces hardcoded `[DEBUG]` log output (#31)
- **`clean-merged` subcommand** — post-PR worktree cleanup (#30)
- **Auto-update `global-context.md`** after each feature completes (#32)

### Fixes

- Collapse pid-file reads and remove JS-interpolation vectors in ingest
- Pin Homebrew formula to commit SHA for stable URLs

### CI

- Grant `pull-requests: write` permission to cleanup-reminder workflow

### Tests

- bats coverage for pid-file reads and injection hardening
- Unit tests for ADR-008/009 modules (cost, cycle_gate, size_gate, router)
- Unit tests for `--verbose` flag and debug output gating
- Unit tests for `gc_append_feature_summary`

---

## Formula changes

- Version: `7.4.0` → `7.5.0`
- URL: switched from pinned commit SHA to tag-based URL (`refs/tags/v7.5.0`)
- SHA256: `54ff0cc2294c0d7dbfa2e844cf591cf38513ae23259a27dbcf56a0abfcc4eebd`

## Test plan

- [ ] `brew install viniciuscarvalho/tap/feature-marker` succeeds on a clean tap
- [ ] `brew upgrade feature-marker` picks up v7.5.0
- [ ] `feature-marker-install` runs without errors post-upgrade
- [ ] `feature-marker-orchestrate --help` returns usage output
