### PR TITLE
fix: move git-repo check after CLI parsing so --help works outside a repo

### DIFF
--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -36,13 +36,6 @@ fi
 # Project root is always the current working directory
 PROJECT_ROOT="$(pwd)"
 
-# Verify we're in a git repo
-if ! git rev-parse --is-inside-work-tree &>/dev/null; then
-  echo "✗ Not inside a git repository." >&2
-  echo "  Run this from the root of your project." >&2
-  exit 1
-fi
-
 # Source modules from SCRIPT_DIR (Homebrew or local)
 LIB_DIR="$SCRIPT_DIR/lib"
 TEMPLATES_DIR="$SCRIPT_DIR/templates"
@@ -178,6 +171,13 @@ done
 export OPT_SKIP_CYCLE_CHECK
 
 [ -z "$SUBCOMMAND" ] && { err "No command given. Run: ./scripts/orchestrate.sh --help"; exit 1; }
+
+# Verify we're in a git repo (--help exits inside arg parsing before reaching here)
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+  echo "✗ Not inside a git repository." >&2
+  echo "  Run this from the root of your project." >&2
+  exit 1
+fi
 
 # ══════════════════════════════════════════════════════════════════
 # Subcommand: init


### PR DESCRIPTION
## Summary

- `feature-marker-orchestrate --help` exited 1 from non-git dirs (Homebrew test temp dir) because the git-repo guard ran before CLI parsing
- Moved the guard to after the while loop — `--help` exits 0 inside the loop before the check; all subcommands still get the protection

## Root cause

`brew test` runs from a temp dir. The first assertion `assert_match "Usage:", shell_output("... --help")` failed because the script exited 1 before printing anything.

## Test plan

- [x] `brew test feature-marker` passes (exit 0)
- [x] `feature-marker-orchestrate run` outside a git repo still errors correctly
- [x] `feature-marker-orchestrate init` inside a fresh git repo still works
