### PR TITLE
fix(context-gatherer): resolve Phase 0.1 failures — tools, slug, mkdir, resume

### DIFF
--- a/feature-marker-dist/feature-marker/resources/spec-workflow/skills/context-gatherer/SKILL.md
+++ b/feature-marker-dist/feature-marker/resources/spec-workflow/skills/context-gatherer/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: context-gatherer
 description: Phase 0.1 — Automatic codebase scan before PRD generation. Extracts key terms from the user prompt, searches the codebase for related files, identifies existing patterns, and generates context.md in the state directory.
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - Bash(mkdir:*)
 ---
 
 # Context Gatherer
@@ -8,20 +14,39 @@ description: Phase 0.1 — Automatic codebase scan before PRD generation. Extrac
 Runs **automatically as Phase 0.1**, before `idea-explorer` asks its first question.
 Purpose: ground the entire spec in the actual codebase — not assumptions.
 
+## Slug generation
+
+Derive `{slug}` from the user's prompt before doing anything else:
+
+1. Lowercase the full prompt string
+2. Remove punctuation
+3. Split into words; skip stop words: `a an the to for of in with from and or but is are was`
+4. Take the first 6 significant words
+5. Join with hyphens; truncate to 60 characters
+
+**Example:**
+
+```
+Prompt: "Allow personal trainers to connect with students after checkout"
+Slug:   allow-personal-trainers-connect-students-checkout
+```
+
 ## When to run
 
 - Always runs before the first `idea-explorer` question
-- Skips if `.claude/feature-state/{slug}/context.md` already exists (resume)
-- Can be forced with `--recontextualize`
+- If `.claude/feature-state/{slug}/context.md` already exists: **load it** (do not re-scan — resume flow)
+- Rerun from scratch only when explicitly asked
 
 ## Step 1: Extract key terms from the user prompt
 
 Parse the user's feature prompt for:
+
 - **Entities**: nouns that likely map to data models (e.g., "student", "trainer", "subscription")
 - **Actions**: verbs that describe behavior (e.g., "connect", "enroll", "notify", "list")
 - **Domain words**: business-specific terms (e.g., "checkout", "onboarding", "dashboard")
 
 Example:
+
 ```
 Prompt: "Allow personal trainers to connect with students after checkout"
 Key terms: ["trainer", "student", "connect", "checkout", "personal trainer"]
@@ -29,60 +54,64 @@ Key terms: ["trainer", "student", "connect", "checkout", "personal trainer"]
 
 ## Step 2: Search the codebase for related files
 
-For each extracted key term, search across the codebase:
+For each extracted key term, use the **Grep tool** (not bash grep — Bash is not available for
+search in this skill):
 
-```bash
-# Search in source files (code, types, schemas)
-grep -r "{term}" . \
-  --include="*.ts" --include="*.tsx" --include="*.js" \
-  --include="*.swift" --include="*.rs" --include="*.py" --include="*.go" \
-  -l 2>/dev/null | head -20
+- Run one Grep call per term, case-insensitive (`-i`), `output_mode: "files_with_matches"`
+- Glob filter covering source files: `*.{ts,tsx,js,swift,rs,py,go}`
+- Also search test files separately with glob: `*{test,spec}*`
 
-# Search in test files
-grep -r "{term}" . --include="*test*" --include="*spec*" -l 2>/dev/null | head -10
-```
-
-Deduplicate results and score by frequency of term occurrence.
-Select the **5–10 most relevant files** (highest term density + most central paths).
+Deduplicate the file lists across all terms. Score each file by how many distinct terms it
+matched. Select the **5–10 most relevant files** (highest match count + most central paths).
 
 ## Step 3: Read project context files
 
 Always read these files if they exist:
 
-| File | Purpose |
-|------|---------|
-| `./CLAUDE.md` | Project-level conventions |
+| File                                 | Purpose                                       |
+| ------------------------------------ | --------------------------------------------- |
+| `./CLAUDE.md`                        | Project-level conventions                     |
 | `./.claude/spec-workflow/PROJECT.md` | Project DNA (architecture rules, constraints) |
-| `./README.md` | Project overview |
-| `./AGENTS.md` | Agent-specific instructions |
-| `./package.json` | Node.js dependencies and scripts |
-| `./Cargo.toml` | Rust dependencies |
-| `./Package.swift` | Swift dependencies |
-| `./go.mod` | Go module info |
+| `./README.md`                        | Project overview                              |
+| `./AGENTS.md`                        | Agent-specific instructions                   |
+| `./package.json`                     | Node.js dependencies and scripts              |
+| `./Cargo.toml`                       | Rust dependencies                             |
+| `./Package.swift`                    | Swift dependencies                            |
+| `./go.mod`                           | Go module info                                |
 
 ## Step 4: Extract existing patterns
 
 From the files identified in Steps 2–3, extract:
 
 ### Architecture patterns
+
 - What patterns are in use? (MVVM, Repository, Clean Architecture, MVC, etc.)
 - Where are they located in the project?
 
 ### Naming conventions
+
 - How are entities named? (camelCase, snake_case, PascalCase)
 - How are files named? (feature-name.ts, FeatureName.swift, etc.)
 
 ### Similar features
+
 - Is there already a feature similar to what's being requested?
 - Which files implement it? What can be reused or extended?
 
 ### Existing entities related to the prompt
+
 - Do any of the key terms already have implementations?
 - What fields, methods, or relationships do they already have?
 
 ## Step 5: Generate context.md
 
-Save to `.claude/feature-state/{slug}/context.md`:
+First, create the state directory so the Write tool doesn't fail:
+
+```bash
+mkdir -p .claude/feature-state/{slug}
+```
+
+Then write to `.claude/feature-state/{slug}/context.md` using the Write tool:
 
 ```markdown
 ## Context Report
@@ -91,31 +120,37 @@ Generated: {timestamp}
 Prompt: "{original prompt}"
 
 ### Related Files Found
+
 - `path/to/file1` — [why it's relevant, e.g., "implements Student entity"]
 - `path/to/file2` — [e.g., "Firestore queries for trainer data"]
 - `path/to/file3` — [e.g., "authentication middleware used by all API routes"]
 
 ### Existing Patterns
+
 - Architecture: MVVM + Repository + Use Cases
 - Auth: Firebase Auth — ID token in Authorization header on all routes
 - Data: Firestore with soft delete (status: 'archived')
 - Naming: Firebase UIDs stored as 'uid' throughout
 
 ### Similar Features Already Implemented
+
 - **Student enrollment** at `src/api/students/` — creates Firestore docs via Cloud Function
 - **Trainer profile** at `Presentation/Features/Trainer/` — MVVM pattern, fetches from /api/trainers
 
 ### Entities Related to Prompt
+
 - **Student** — exists at `src/types/student.ts`, fields: uid, name, email, trainerId?
 - **Trainer** — exists at `src/types/trainer.ts`, fields: uid, name, specialization[]
 - **checkout** — Cloud Function `handleCheckoutComplete` creates student records after Stripe payment
 
 ### Constraints Detected
+
 - Stripe webhook creates student-trainer relationships — any new connection flow should integrate with this
 - FCM token not guaranteed — push notifications are optional for all users
 - Feature flags via Firebase Remote Config — new user-facing features need a flag
 
 ### What DOESN'T Exist (Relevant to Prompt)
+
 - No direct trainer-student connection endpoint outside of checkout
 - No student list view for trainers in CMS
 - No real-time listener for connection status
@@ -151,6 +186,7 @@ Injecting this context into spec generation...
 ```
 
 This file is:
+
 - **Injected into idea-explorer** as initial context (question framing)
 - **Injected into spec-writer** as architectural context
 - **Referenced during PRD Validation** to verify entity references

--- a/feature-marker-dist/feature-marker/resources/spec-workflow/skills/idea-explorer/SKILL.md
+++ b/feature-marker-dist/feature-marker/resources/spec-workflow/skills/idea-explorer/SKILL.md
@@ -10,6 +10,7 @@ allowed-tools:
   - Bash(git status:*)
   - Bash(git log:*)
   - Bash(ls *)
+  - Bash(mkdir:*)
   - Write
 ---
 
@@ -38,7 +39,7 @@ Check for `.claude/spec-workflow/config.yaml` in the project. If present, use co
 
 ```yaml
 paths:
-  specs: "./specs"  # Where to save output if --output not specified
+  specs: "./specs" # Where to save output if --output not specified
 ```
 
 If no config exists, default to `./specs/`.
@@ -50,12 +51,14 @@ This file contains permanent project context: stack, architecture rules, code co
 known constraints, and what "done" means for this project.
 
 When PROJECT.md is present:
+
 - Inject Architecture Rules into your exploration questions
 - Reference known constraints when evaluating feasibility
 - Use "Out of Scope" section to apply YAGNI ruthlessly
 - Frame questions in terms of the actual stack (e.g., "This project uses Firestore — should the new entity follow the soft-delete pattern already in use?")
 
 If PROJECT.md does **not** exist, offer to generate it:
+
 ```
 ⚠️ No PROJECT.md found at .claude/spec-workflow/PROJECT.md
    This file enriches all spec phases with permanent project context.
@@ -74,11 +77,14 @@ If `.claude/spec-workflow/philosophy/exploration.md` exists, read it and incorpo
 
 Before asking the user anything, gather codebase context:
 
+**Derive `{slug}`** from the feature topic using the same rule as `context-gatherer`:
+lowercase → strip punctuation → drop stop words (`a an the to for of in with from and or but is are was`) → first 6 significant words → join with hyphens → max 60 chars.
+
 1. Parse the feature topic/prompt for key terms (entities, actions, domain words)
-2. Grep/glob the codebase for files containing those terms — find the **5–10 most relevant files**
+2. Use the **Grep tool** (not bash grep) per term — `output_mode: "files_with_matches"`, `-i`, glob `*.{ts,tsx,js,swift,rs,py,go}` — find the **5–10 most relevant files**
 3. Read project context files: `CLAUDE.md`, `.claude/spec-workflow/PROJECT.md`, `README.md`, stack config
 4. Identify existing patterns, similar features, and related entities already in the codebase
-5. Save context to `.claude/feature-state/{slug}/context.md` (load if already exists)
+5. If `.claude/feature-state/{slug}/context.md` already exists, **load it** (skip re-scan); otherwise run `mkdir -p .claude/feature-state/{slug}` then write it with the Write tool
 6. Show a brief summary before the first question:
    ```
    📂 Context gathered — 7 related files found.
@@ -106,9 +112,10 @@ After saving `context.md`, run the **prompt-enricher** phase to ground the raw p
    - notify/push/email → notification edge cases
    - webhook/API/external → external integration edge cases
 5. Suggest scope boundaries (In Scope / Likely Out of Scope YAGNI / Deferred)
-6. Save to `.claude/feature-state/{slug}/enriched-prompt.md` (load if already exists)
+6. If `.claude/feature-state/{slug}/enriched-prompt.md` already exists, **load it** (skip re-enrichment); otherwise write it with the Write tool (directory already created in step 0.5 above)
 
 Use the enriched prompt as the **starting brief** for the first question:
+
 ```
 Based on what I found in the codebase, here's what we're working with:
 
@@ -149,6 +156,7 @@ This purpose of this step is to narrow down and clarify the idea, its purpose, c
 - Avoid feature creep - ruthlessly apply YAGNI (You Ain't Gonna Need It) to remove unnecessary features
 
 Adjust depth based on `--depth` argument:
+
 - `quick`: 2-3 key questions only
 - `normal`: 4-6 questions covering core aspects
 - `thorough`: 8+ questions, explore more alternatives


### PR DESCRIPTION
## What broke

Phase 0.1 (context-gatherer) would silently fail every invocation — context.md was never written, so idea-explorer had no codebase context to inject into specs.

## Bugs fixed

**Bug 1** — No `allowed-tools` in context-gatherer frontmatter: Write tool unavailable, context.md never written.

**Bug 2** — `{slug}` placeholder never defined: non-deterministic path, resume check always missed.

**Bug 3** — No `mkdir -p` before Write: Write fails on missing parent directory.

**Bug 4** — Step 2 used `grep -r` via Bash (not in allowed-tools): codebase scan silently skipped.

**Bug 5** — "Skip if exists" instead of "load if exists": cached context lost on every resume.

## Changes

- **context-gatherer/SKILL.md**: added `allowed-tools` frontmatter (Read/Grep/Glob/Write/Bash(mkdir:\*)); defined canonical slug rule; replaced bash grep with Grep tool instructions; added `mkdir -p` before Write; fixed resume to load-if-exists.
- **idea-explorer/SKILL.md**: added `Bash(mkdir:*)` to allowed-tools; added same slug-derivation rule; fixed enriched-prompt step to load-if-exists.

## Test plan

- [ ] Invoke idea-explorer on a real project — confirm `.claude/feature-state/{slug}/context.md` is created
- [ ] Re-invoke same topic — confirm context.md is loaded without re-scanning
- [ ] Invoke context-gatherer as standalone sub-skill — Write tool is available
- [ ] `brew test feature-marker` exits 0
