### PR TITLE
feat(learning): enable Ollama and semantic embedding retrieval

### DIFF
--- a/orchestrator/config.yml
+++ b/orchestrator/config.yml
@@ -116,7 +116,7 @@ routing:
 learning:
   ttl_days: 90
   similarity:
-    backend: exact # exact | embedding (embedding requires local_model.enabled: true)
+    backend: embedding # exact | embedding (embedding requires local_model.enabled: true)
     threshold: 0.85
 
 execution_timeouts:
@@ -124,7 +124,7 @@ execution_timeouts:
 
 # Local-model integration (ADR-009)
 local_model:
-  enabled: false # opt-in; false = pure-Claude behaviour (zero change for existing users)
+  enabled: true # opt-in; false = pure-Claude behaviour (zero change for existing users)
   provider: ollama # ollama | lm-studio | llama-cpp
   endpoint: http://localhost:11434
   embedding_model: nomic-embed-text
@@ -132,7 +132,7 @@ local_model:
   summarizer_model: llama3.2:3b
   generator_model: null # set to a coder model (e.g. qwen2.5-coder:32b) to enable D8 (experimental)
   timeout_seconds: 10
-  fail_open: true # true = degrade to Claude/exact-match on endpoint error
+  fail_open: false # true = degrade to Claude/exact-match on endpoint error
   engine_per_phase:
     phase_0: script # always script — no model needed
     phase_1: claude # planning requires Opus-grade reasoning


### PR DESCRIPTION
## Summary

- Activates the pre-built local-model learning subsystem (ADR-009) that ships disabled by default
- Flips `local_model.enabled: true` so the Ollama provider at `localhost:11434` is used for embeddings and summarization
- Switches `learning.similarity.backend` from `exact` to `embedding`, enabling cosine-similarity retrieval against `learned.embeddings.jsonl` sidecars — past fixes are now matched by meaning, not literal string overlap
- Sets `local_model.fail_open: false` so the orchestrator hard-fails if Ollama is unreachable, preventing silent learning loss

## What this enables

- **Phase 4.5 (ingest.sh)**: after each merged PR, review comments and CI failure logs are summarized by `llama3.2:3b` and written into the project-tier learning store. Future runs retrieve relevant fixes without a fresh Claude call.
- **Memory context (memory.sh)**: `global-context.md` carry-forward already in place — no change needed.
- **Retrieval**: `learning.sh` cosine search now activates against embedding sidecars (threshold 0.85).

## Models

| Model | Size | Role |
|---|---|---|
| `nomic-embed-text` | 274 MB | Embeddings for all 3 tiers |
| `llama3.2:3b` | 2 GB | Classifier + summarizer in Phase 4.5 |

Both pulled and smoke-tested locally:
- Embedding round-trip: 768-dim vector confirmed
- Summarizer round-trip: valid JSON with confidence 0.85 confirmed

## Known gap (follow-up, not in this PR)

Mid-run user corrections are not yet ingested into the learning store. A follow-up issue will hook supervised-mode checkpoint output into `learning_write`.

## Test plan

- [ ] `ollama serve` running at `localhost:11434` with both models present (`ollama list`)
- [ ] Run a feature through the orchestrator end-to-end; confirm `ingest_reviews` fires after PR merge
- [ ] Check `.claude/feature-state/learned.json` has entries and `learned.embeddings.jsonl` sidecar exists
- [ ] Start a second feature with semantically similar description; confirm orchestrator log shows cosine-similarity hit
- [ ] Stop Ollama and start a run; confirm orchestrator exits with clear error (not silent degradation)
