### PR TITLE
docs: correct depends-on syntax and document checkpoint halt behavior

### DIFF
--- a/assets/HOW_IT_WORKS.md
+++ b/assets/HOW_IT_WORKS.md
@@ -159,7 +159,7 @@ labels: auth, backend
 ## [MEDIUM] feat-002: Webhook retry with backoff
 
 Add retry logic to the webhook dispatcher.
-depends-on: none
+Depends on: none
 
 ## [LOW] feat-003: Dark mode toggle
 
@@ -255,6 +255,8 @@ If no agents are found, Feature-marker handles everything — the system degrade
 
 ```bash
 --autonomy <level>     # supervised | checkpoint | full_auto
+                       # checkpoint: stages worktrees + estimates cost, then halts at
+                       # awaiting-pipeline — Claude does not run until you resume manually
 --adapter <type>       # linear | github | jira | markdown
 --dry-run              # Show plan without executing (use with run)
 --feature <id>         # Run only one feature


### PR DESCRIPTION
## Summary

- **Bug fix**: `depends-on: none` → `Depends on: none` in the `features.md` example at `HOW_IT_WORKS.md:162`. The markdown adapter regex requires a space between `depends` and `on` — a hyphen silently fails, so any feature declared with `depends-on:` would skip the dependency-ordering gate with no error.
- **Clarification**: Added a two-line comment under `--autonomy` in the CLI reference explaining that `checkpoint` mode stages worktrees and estimates cost but halts at `awaiting-pipeline` — Claude does not implement until the user manually resumes. Surfaced by Round 8 of the validation run which completed in ~3s/feature because no generation ran.

## Test plan

- [ ] Confirm `depends-on: none` no longer appears in `HOW_IT_WORKS.md`
- [ ] Read the CLI reference block and verify the `--autonomy` comment is accurate against `scripts/orchestrate.sh` checkpoint dispatch path
- [ ] Run `grep -n "depends-on" assets/HOW_IT_WORKS.md` — should return no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
