### PR TITLE
docs: document per-run log path and verbose output capture

### DIFF
--- a/assets/HOW_IT_WORKS.md
+++ b/assets/HOW_IT_WORKS.md
@@ -262,6 +262,13 @@ If no agents are found, Feature-marker handles everything — the system degrade
 --config <path>        # Use a different config file
 ```
 
+**Per-run logs** are written to `.orchestrator/state/<feat-id>/logs/run-<timestamp>.log`.
+There is no verbose flag; pipe stdout+stderr to capture all output:
+
+```bash
+feature-marker-orchestrate run --feature feat-auth 2>&1 | tee debug.log
+```
+
 ---
 
 ## How the two paths relate


### PR DESCRIPTION
## Summary

- There is no `-v` / `--verbose` flag in the orchestrate CLI parser (`scripts/orchestrate.sh:81-169`). Users trying `-v` get `Unknown argument: -v` and no output is captured.
- Per-run logs are already written to `.orchestrator/state/<feat-id>/logs/run-<timestamp>.log` by `scripts/orchestrator.sh:353`, but this was not documented anywhere in the user-facing reference.
- Add a short note in the CLI reference section of `HOW_IT_WORKS.md` documenting the log path and the standard `2>&1 | tee` pattern as the way to capture full output.

## Test plan

- [ ] Verify log path is correct: run `feature-marker-orchestrate run --feature <id>` and confirm a file appears under `.orchestrator/state/<id>/logs/`
- [ ] Confirm no `LOG_LEVEL` or `-v` is referenced in the new text (both are phantom variables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
