### PR TITLE
docs(cost): clarify phase2 estimate variance is routing-dependent

### DIFF
--- a/scripts/lib/cost.sh
+++ b/scripts/lib/cost.sh
@@ -52,6 +52,12 @@ cost_init() {
 #   task_count  : number of tasks (relevant for phase 2 and phase 3 fix attempts)
 #   agent_type  : "specialist" | "generic"
 # Prints the estimated token count to stdout.
+#
+# Note: phase 2 estimates are routing-dependent. A feature routed to a
+# specialist agent (e.g. swift-expert) uses COST_PHASE_2_SPECIALIST (8K/task
+# default), while feature-marker fallback uses COST_PHASE_2_GENERIC (12K/task
+# default). The same feature can show different phase 2 estimates across runs
+# if agent availability changes — this is expected, not a bug.
 
 cost_estimate_phase() {
   local phase="$1"


### PR DESCRIPTION
## Summary

Investigation of the `feat-search` cost anomaly observed across validation Rounds 5 and 8 (phase2 estimate 8K → 12K). Findings and a doc note added.

## Findings

**Not a bug — expected routing-dependent behavior:**

| Scenario                             | Agent routed                | phase2 per task | Source constant           |
| ------------------------------------ | --------------------------- | --------------- | ------------------------- |
| Round 5 (swift-expert detected)      | `swift-expert` (specialist) | **8,000**       | `COST_PHASE_2_SPECIALIST` |
| Round 8 (swift-expert not installed) | `feature-marker` (generic)  | **12,000**      | `COST_PHASE_2_GENERIC`    |

The estimate correctly reflects which agent will consume tokens. Estimates for the same feature will differ across environments with different agent packs installed — this is by design.

**Phase memoization is stable (Round 6):** Repeat runs of `feat-auth` produced identical token counts (67,000 both times); diff showed only timestamp differences.

## Change

Added a comment to `cost_estimate_phase` in `scripts/lib/cost.sh` explaining the routing-dependency so future readers don't mistake the legitimate variance for a bug.

## Test plan

- [ ] Run `feature-marker-orchestrate run --feature feat-search` with swift-expert installed — confirm phase2 = 8K
- [ ] Run again without swift-expert — confirm phase2 = 12K
- [ ] Verify Round 6 diff shows only timestamp differences (token counts identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
