### PR TITLE
feat(autonomy): wire full_auto to skip Claude permissions and extend Ralph Loop

### DIFF
--- a/assets/HOW_IT_WORKS.md
+++ b/assets/HOW_IT_WORKS.md
@@ -97,13 +97,9 @@ The orchestrator is a bash script that runs **outside** Claude Code, in your reg
 
 ```bash
 # First time: scaffold config files
-./scripts/orchestrate.sh init
+feature-marker-orchestrate init
 
 # Run the orchestration loop
-./scripts/orchestrate.sh run
-
-# Or with Homebrew
-feature-marker-orchestrate init
 feature-marker-orchestrate run
 ```
 
@@ -120,7 +116,7 @@ The orchestrator is a `for` loop in bash. For each feature in the backlog, it ca
 **1. Initialize** — creates config files in your project:
 
 ```bash
-./scripts/orchestrate.sh init
+feature-marker-orchestrate init
 # Creates:
 #   .orchestrator/config.yaml   — settings (committed to git)
 #   .env.example                — API key template (committed)
@@ -171,13 +167,13 @@ For `linear` or `github`, the orchestrator fetches issues automatically based on
 **5. Preview** — see what would happen without executing:
 
 ```bash
-./scripts/orchestrate.sh run --dry-run
+feature-marker-orchestrate run --dry-run
 ```
 
 **6. Run**:
 
 ```bash
-./scripts/orchestrate.sh run
+feature-marker-orchestrate run
 ```
 
 ### Backlog sources
@@ -204,7 +200,7 @@ All API keys live in `.env` (never committed). The `config.yaml` only has parame
 Override per run:
 
 ```bash
-./scripts/orchestrate.sh run --autonomy full_auto
+feature-marker-orchestrate run --autonomy full_auto
 ```
 
 **What `full_auto` actually does differently:**
@@ -257,10 +253,10 @@ If no agents are found, Feature-marker handles everything — the system degrade
 **Subcommands:**
 
 ```bash
-./scripts/orchestrate.sh run          # Execute the orchestration loop
-./scripts/orchestrate.sh init         # Scaffold config files
-./scripts/orchestrate.sh status       # Show current state
-./scripts/orchestrate.sh clean        # Remove worktrees + reset state
+feature-marker-orchestrate run          # Execute the orchestration loop
+feature-marker-orchestrate init         # Scaffold config files
+feature-marker-orchestrate status       # Show current state
+feature-marker-orchestrate clean        # Remove worktrees + reset state
 ```
 
 **Flags:**
@@ -291,7 +287,7 @@ feature-marker-orchestrate run --feature feat-auth 2>&1 | tee debug.log
 ┌─────────────────────────────────────────────────────┐
 │              Your terminal                           │
 │                                                      │
-│  ./scripts/orchestrate.sh run                        │
+│  feature-marker-orchestrate run                        │
 │     │                                                │
 │     ├─ reads config.yaml + .env                      │
 │     ├─ fetches backlog (Linear / GitHub / .md)       │

--- a/assets/HOW_IT_WORKS.md
+++ b/assets/HOW_IT_WORKS.md
@@ -111,7 +111,7 @@ feature-marker-orchestrate run
 
 ### How it works step by step
 
-The orchestrator is a `for` loop in bash. For each feature in the backlog, it calls `claude --skill feature-marker` to run the pipeline. When Claude finishes, control returns to bash — it collects results and updates memory. Once all features finish, the loop creates PRs and cleans up worktrees in a single pass.
+The orchestrator is a `for` loop in bash. For each feature in the backlog, it calls `claude --agent feature-marker` to run the pipeline. When Claude finishes, control returns to bash — it collects results and updates memory. Once all features finish, the loop creates PRs and cleans up worktrees in a single pass.
 
 ![Terminal execution flow](./orchestrator-terminal-flow.png)
 
@@ -209,8 +209,8 @@ Override per run:
 
 **What `full_auto` actually does differently:**
 
-- Passes `--dangerously-skip-permissions` to every Claude invocation so file
-  writes, bash commands, and network calls run without interactive prompts.
+- Passes `--permission-mode bypassPermissions` to every Claude invocation so
+  file writes, bash commands, and network calls run without interactive prompts.
   The orchestrator prints a warning banner before each feature.
 - Extends the Phase 3 Ralph Loop from 2 fix attempts to 5 (override via
   `CFG_PHASE3_FULL_AUTO_MAX_FIX_ATTEMPTS`). Each fix attempt reads from and
@@ -297,7 +297,7 @@ feature-marker-orchestrate run --feature feat-auth 2>&1 | tee debug.log
 │     ├─ fetches backlog (Linear / GitHub / .md)       │
 │     ├─ for each feature:                             │
 │     │    ├─ git worktree add                         │
-│     │    ├─ claude --skill feature-marker            │ ← calls Claude Code
+│     │    ├─ claude --agent feature-marker            │ ← calls Claude Code
 │     │    │         prd-<feat-id>                     │
 │     │    │    └─ Feature-marker skill runs           │ ← same skill as Path 1
 │     │    │       PRD → TechSpec → Tasks → Code       │

--- a/assets/HOW_IT_WORKS.md
+++ b/assets/HOW_IT_WORKS.md
@@ -207,6 +207,18 @@ Override per run:
 ./scripts/orchestrate.sh run --autonomy full_auto
 ```
 
+**What `full_auto` actually does differently:**
+
+- Passes `--dangerously-skip-permissions` to every Claude invocation so file
+  writes, bash commands, and network calls run without interactive prompts.
+  The orchestrator prints a warning banner before each feature.
+- Extends the Phase 3 Ralph Loop from 2 fix attempts to 5 (override via
+  `CFG_PHASE3_FULL_AUTO_MAX_FIX_ATTEMPTS`). Each fix attempt reads from and
+  writes to the 3-tier learning store, so repeated failures across features
+  converge on known-good fixes.
+- Use this only in sandboxed environments (isolated worktrees, disposable
+  CI runners) where unattended shell access is acceptable.
+
 ### Memory between features
 
 The orchestrator keeps three layers of context that accumulate as features complete:

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -335,6 +335,19 @@ EOPRD
   local interactive_flag=""
   [ "$AUTONOMY" = "supervised" ] && interactive_flag="--interactive"
 
+  # full_auto skips Claude's permission prompts so the pipeline can run
+  # unattended. The extended Ralph Loop (run_phase3_tests) compensates by
+  # giving Claude more fix attempts and feeding the learning store.
+  local perm_flag=""
+  if [ "$AUTONOMY" = "full_auto" ]; then
+    perm_flag="--dangerously-skip-permissions"
+    echo ""
+    echo "  ⚠  FULL_AUTO — passing --dangerously-skip-permissions to Claude"
+    echo "     File writes, bash commands, and network calls run WITHOUT prompts."
+    echo "     Phase 3 Ralph Loop active — learning store captures fixes and failures."
+    echo ""
+  fi
+
   # ADR-009 PR-H: quality-warning banner when local generator replacement is active
   if [ "${LOCAL_MODEL_ENABLED:-false}" = "true" ] && [ -n "${LOCAL_MODEL_GENERATOR_MODEL:-}" ]; then
     echo ""
@@ -346,7 +359,7 @@ EOPRD
 
   info "Autonomy=$AUTONOMY — invoking pipeline (model: ${MODEL_DEFAULT:-default}, agent: $skill_arg)..."
   (cd "$wt_path" && op_timeout "${SKILL_TIMEOUT_SECONDS:-1800}" \
-    claude --skill "$skill_arg" ${interactive_flag:+$interactive_flag} "prd-$feat_id") 2>&1 \
+    claude --skill "$skill_arg" $perm_flag ${interactive_flag:+$interactive_flag} "prd-$feat_id") 2>&1 \
     | tee "$log_file" || exit_code=$?
 
   # ── ADR-008 PR-A: Phase 3 scripted tests ────────────────────────
@@ -511,8 +524,12 @@ run_phase3_tests() {
   test_output=$(cat /tmp/phase3-test-output-$$.txt 2>/dev/null || echo "test output unavailable")
   rm -f /tmp/phase3-test-output-$$.txt
 
-  # Fix loop — max 2 attempts
+  # Fix loop — default 2 attempts; full_auto runs an extended Ralph Loop.
   local max_fix_attempts=2
+  if [ "$AUTONOMY" = "full_auto" ]; then
+    max_fix_attempts="${CFG_PHASE3_FULL_AUTO_MAX_FIX_ATTEMPTS:-5}"
+    info "Phase 3: Ralph Loop active — up to $max_fix_attempts fix attempts (full_auto)"
+  fi
 
   while [ "$fix_attempts" -lt "$max_fix_attempts" ]; do
     fix_attempts=$((fix_attempts + 1))
@@ -539,9 +556,12 @@ run_phase3_tests() {
     local model_flag=""
     [ -n "${MODEL_DEFAULT:-}" ] && model_flag="--model $MODEL_DEFAULT"
 
+    local fix_perm_flag=""
+    [ "$AUTONOMY" = "full_auto" ] && fix_perm_flag="--dangerously-skip-permissions"
+
     local fix_exit=0
     if command -v claude &>/dev/null; then
-      (cd "$wt_path" && printf '%b' "$fix_prompt" | claude $model_flag --print) 2>/dev/null || fix_exit=$?
+      (cd "$wt_path" && printf '%b' "$fix_prompt" | claude $model_flag $fix_perm_flag --print) 2>/dev/null || fix_exit=$?
     else
       info "Phase 3: Claude CLI not found — cannot attempt fix"
       return 1

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -335,14 +335,20 @@ EOPRD
   local interactive_flag=""
   [ "$AUTONOMY" = "supervised" ] && interactive_flag="--interactive"
 
+  # Translate internal model aliases (e.g. "opusplan") to Claude CLI-compatible names.
+  # "opusplan" means Opus for planning / Sonnet for execution; Phase 2 uses Opus.
+  local effective_model="${MODEL_DEFAULT:-}"
+  [ "$effective_model" = "opusplan" ] && effective_model="opus"
+
   # full_auto skips Claude's permission prompts so the pipeline can run
-  # unattended. The extended Ralph Loop (run_phase3_tests) compensates by
-  # giving Claude more fix attempts and feeding the learning store.
+  # unattended. --permission-mode bypassPermissions avoids the interactive
+  # "Verify the reason" confirmation that --dangerously-skip-permissions triggers.
+  # The extended Ralph Loop (run_phase3_tests) compensates with more fix attempts.
   local perm_flag=""
   if [ "$AUTONOMY" = "full_auto" ]; then
-    perm_flag="--dangerously-skip-permissions"
+    perm_flag="--permission-mode bypassPermissions"
     echo ""
-    echo "  ⚠  FULL_AUTO — passing --dangerously-skip-permissions to Claude"
+    echo "  ⚠  FULL_AUTO — running with bypassPermissions mode"
     echo "     File writes, bash commands, and network calls run WITHOUT prompts."
     echo "     Phase 3 Ralph Loop active — learning store captures fixes and failures."
     echo ""
@@ -357,9 +363,9 @@ EOPRD
     echo ""
   fi
 
-  info "Autonomy=$AUTONOMY — invoking pipeline (model: ${MODEL_DEFAULT:-default}, agent: $skill_arg)..."
+  info "Autonomy=$AUTONOMY — invoking pipeline (model: ${effective_model:-default}, agent: $skill_arg)..."
   (cd "$wt_path" && op_timeout "${SKILL_TIMEOUT_SECONDS:-1800}" \
-    claude ${MODEL_DEFAULT:+--model "$MODEL_DEFAULT"} --agent "$skill_arg" $perm_flag ${interactive_flag:+$interactive_flag} -p "prd-$feat_id") 2>&1 \
+    claude ${effective_model:+--model "$effective_model"} --agent "$skill_arg" $perm_flag ${interactive_flag:+$interactive_flag} -p "prd-$feat_id") 2>&1 \
     | tee "$log_file" || exit_code=$?
 
   # ── ADR-008 PR-A: Phase 3 scripted tests ────────────────────────
@@ -554,10 +560,12 @@ run_phase3_tests() {
     fi
 
     local model_flag=""
-    [ -n "${MODEL_DEFAULT:-}" ] && model_flag="--model $MODEL_DEFAULT"
+    local _fix_model="${MODEL_DEFAULT:-}"
+    [ "$_fix_model" = "opusplan" ] && _fix_model="opus"
+    [ -n "$_fix_model" ] && model_flag="--model $_fix_model"
 
     local fix_perm_flag=""
-    [ "$AUTONOMY" = "full_auto" ] && fix_perm_flag="--dangerously-skip-permissions"
+    [ "$AUTONOMY" = "full_auto" ] && fix_perm_flag="--permission-mode bypassPermissions"
 
     local fix_exit=0
     if command -v claude &>/dev/null; then

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -359,7 +359,7 @@ EOPRD
 
   info "Autonomy=$AUTONOMY — invoking pipeline (model: ${MODEL_DEFAULT:-default}, agent: $skill_arg)..."
   (cd "$wt_path" && op_timeout "${SKILL_TIMEOUT_SECONDS:-1800}" \
-    claude --skill "$skill_arg" $perm_flag ${interactive_flag:+$interactive_flag} "prd-$feat_id") 2>&1 \
+    claude ${MODEL_DEFAULT:+--model "$MODEL_DEFAULT"} --agent "$skill_arg" $perm_flag ${interactive_flag:+$interactive_flag} -p "prd-$feat_id") 2>&1 \
     | tee "$log_file" || exit_code=$?
 
   # ── ADR-008 PR-A: Phase 3 scripted tests ────────────────────────


### PR DESCRIPTION
## Summary

Make `full_auto` live up to its name. Previously, `AUTONOMY=full_auto` set one config flag but still shelled out to `claude` without any permission-bypass, so every file write, bash exec, and network call would prompt the user — defeating the purpose of running unattended.

This PR wires `full_auto` to pass `--dangerously-skip-permissions` to Claude, and extends the Phase 3 Ralph Loop so the autonomous mode has enough fix budget to converge on its own, leaning on the existing learning-store infrastructure.

## Changes

### `scripts/lib/runner.sh`

1. **Main pipeline invocation (feature entry)**: derive `perm_flag` from `AUTONOMY`. In `full_auto`, `perm_flag="--dangerously-skip-permissions"` and a three-line warning banner prints before the Claude call:

   ```text
   ⚠  FULL_AUTO — passing --dangerously-skip-permissions to Claude
      File writes, bash commands, and network calls run WITHOUT prompts.
      Phase 3 Ralph Loop active — learning store captures fixes and failures.
   ```

2. **Phase 3 fix loop (`run_phase3_tests`)**:
   - Raise `max_fix_attempts` from `2` → `5` in `full_auto` (override via `CFG_PHASE3_FULL_AUTO_MAX_FIX_ATTEMPTS`).
   - Pass `--dangerously-skip-permissions` to the fix-attempt invocation so Claude can edit files and run commands without prompts.
   - The existing `learning_read`/`learning_write` path already feeds successes and failures into the 3-tier store (feature/project/global) — no new learning plumbing needed; more attempts just means more signal flows through.

### `assets/HOW_IT_WORKS.md`

Added a short block under the Autonomy levels table explaining:

- `full_auto` passes `--dangerously-skip-permissions` (with warning banner)
- Ralph Loop budget bumps to 5 attempts (configurable)
- Should only run in sandboxed environments

## Behavior matrix after this PR

| Autonomy     | Flags passed to Claude                                   | Phase 3 budget                  |
| ------------ | -------------------------------------------------------- | ------------------------------- |
| `supervised` | `--skill <name> --interactive prd-<id>`                  | n/a (interactive handles tests) |
| `checkpoint` | `--skill <name> prd-<id>`                                | 2 fix attempts                  |
| `full_auto`  | `--skill <name> --dangerously-skip-permissions prd-<id>` | 5 fix attempts (configurable)   |

## Test plan

- [ ] `AUTONOMY=checkpoint` run — verify banner does NOT print and no permission flag is passed (inspect log)
- [ ] `AUTONOMY=full_auto` run — verify banner prints and Claude runs without prompting on file writes
- [ ] Force a test failure in `full_auto` — verify fix attempts progress past `2/2` up to `5/5`
- [ ] Override with `CFG_PHASE3_FULL_AUTO_MAX_FIX_ATTEMPTS=3` — verify cap honored
- [ ] Inspect `.orchestrator/state/<feat>/learned.json` after a fix — entries should have `success_count` or `failure_count` incremented

## Risk

- `--dangerously-skip-permissions` is exactly as dangerous as it sounds. The opt-in contract: users choose `full_auto` knowing the tradeoff. Banner makes it audible in logs.
- The 5-attempt default might waste tokens on genuinely stuck features. Configurable via env var so operators can tune down.
- No behavior change for `supervised` or `checkpoint` — permission prompts still work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
