### PR TITLE
chore: release v7.6.0 — update Homebrew formula

### DIFF
--- a/homebrew/feature-marker.rb
+++ b/homebrew/feature-marker.rb
@@ -6,9 +6,9 @@
 class FeatureMarker < Formula
   desc "AI-powered feature development automation — skill + orchestrator"
   homepage "https://github.com/Viniciuscarvalho/Feature-marker"
-  url "https://github.com/Viniciuscarvalho/Feature-marker/archive/refs/tags/v7.5.0.tar.gz"
-  sha256 "54ff0cc2294c0d7dbfa2e844cf591cf38513ae23259a27dbcf56a0abfcc4eebd"
-  version "7.5.0"
+  url "https://github.com/Viniciuscarvalho/Feature-marker/archive/refs/tags/v7.6.0.tar.gz"
+  sha256 "df1723649c1caa48ec7d7aee7b0d47d6f2a79b3cbd0cd8bfd282cac2f4de8d9e"
+  version "7.6.0"
   license "MIT"
   head "https://github.com/Viniciuscarvalho/Feature-marker.git", branch: "main"
 


### PR DESCRIPTION
## Summary

- Bumps Homebrew formula to `v7.6.0`
- Updates tarball URL to `archive/refs/tags/v7.6.0.tar.gz`
- Updates `sha256` to match the new tag archive
- Updates `version` to `7.6.0`

## Test plan

- [ ] `brew upgrade viniciuscarvalho/tap/feature-marker` installs cleanly
- [ ] `feature-marker-orchestrate --help` works after upgrade
- [ ] `feature-marker-install` copies skill files correctly
