### PR TITLE
feat(ux): live backlog table, next-steps guidance, and accurate summary stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Ollama & semantic embedding retrieval** (PR #39) — Learning module now integrates with Ollama for local semantic embeddings; retrieved context is ranked by cosine similarity and injected into the orchestrator prompt at the start of each feature run
-- **`full_auto` mode with `--dangerously-skip-permissions` and Ralph Loop** (PR #43) — Full-autonomy run path now passes `--dangerously-skip-permissions` to Claude Code so the inner agent never stalls on a permission prompt; the outer retry loop (Ralph Loop) keeps cycling until the feature reaches DONE or the retry budget is exhausted
+- **`full_auto` mode with extended Ralph Loop** (PR #43) — Full-autonomy run path uses `--permission-mode bypassPermissions` so the inner agent never stalls on a permission prompt (replaces `--dangerously-skip-permissions`, which triggered an interactive "Verify the reason" confirmation in `-p` mode); the outer retry loop (Ralph Loop) keeps cycling until the feature reaches DONE or the retry budget is exhausted
 
 ### Fixed
 
 - **`--help` outside a git repo** (PR #36) — CLI argument parsing now runs before the git-repo guard; `feature-marker-orchestrate --help` works in any directory, not just inside a git repo
 - **Context-gatherer Phase 0.1 failures** (PR #37) — Resolved a cluster of failures: missing tool declarations in the gatherer prompt, slug generation edge cases, `mkdir -p` race condition on worktree init, and incorrect resume-state detection after a partial run
-- **`full_auto` hang and invalid model flag** (PR #43) — Corrected the Claude CLI flags used in the `full_auto` runner; the hang introduced in v7.5.0 (noted as a known regression) is resolved
+- **`full_auto` hang and invalid model flag** (PR #43) — Replaced `--dangerously-skip-permissions` (which blocks `-p` mode with an interactive confirmation) with `--permission-mode bypassPermissions`; also translates the internal `opusplan` alias to `opus` before passing `--model` to the Claude CLI. Both changes applied to Phase 2 invocation and Phase 3 Ralph Loop fix attempts
 
 ### Documentation
 

--- a/scripts/lib/display.sh
+++ b/scripts/lib/display.sh
@@ -40,6 +40,54 @@ display_backlog() {
   echo "    Done:    $done_count"
 }
 
+# display_backlog_table [active_feat_id]
+# Prints a live table of all features in STATE_DIR with status, phase, and token cost.
+display_backlog_table() {
+  local active_feat="${1:-}"
+  [ ! -d "$STATE_DIR" ] && return
+  node -e "
+    const fs = require('fs'), path = require('path');
+    const sd = '$STATE_DIR', active = '$active_feat';
+    let dirs;
+    try { dirs = fs.readdirSync(sd).filter(d => fs.existsSync(path.join(sd,d,'status.json'))); }
+    catch(e) { process.exit(0); }
+    if (!dirs.length) process.exit(0);
+    const features = dirs.map(d => {
+      const s = JSON.parse(fs.readFileSync(path.join(sd,d,'status.json'),'utf-8'));
+      let tokens = 0;
+      try { tokens = JSON.parse(fs.readFileSync(path.join(sd,d,'cost.json'),'utf-8')).cumulative_tokens||0; } catch(e){}
+      return { id: d, status: s.status, phase: s.phase||'pending', tokens };
+    });
+    const doneN = features.filter(f=>f.status==='done'||f.status==='pr-created').length;
+    const totalTok = features.reduce((s,f)=>s+f.tokens,0);
+    const fmtTok = n => n>=1000 ? Math.round(n/1000)+'k' : (n||'—');
+    const icon = f => {
+      if (f.id===active||f.status==='in-progress') return '→';
+      if (f.status==='done'||f.status==='pr-created') return '✓';
+      if (f.status==='failed') return '✗';
+      if (f.status==='paused') return '⏸';
+      return '·';
+    };
+    const hdr = '  BACKLOG  ['+doneN+'/'+features.length+' done]'+(totalTok?' — ~'+fmtTok(totalTok)+' tokens':'');
+    const W = 64;
+    const pad = (s,n) => String(s).substring(0,n).padEnd(n);
+    console.log('');
+    console.log('  ┌'+'─'.repeat(W)+'┐');
+    console.log('  │  '+hdr.padEnd(W-2)+'│');
+    console.log('  ├'+'─'.repeat(16)+'┬'+'─'.repeat(14)+'┬'+'─'.repeat(14)+'┬'+'─'.repeat(18)+'┤');
+    console.log('  │  '+pad('Feature',14)+'│  '+pad('Status',12)+'│  '+pad('Phase',12)+'│  '+pad('Tokens',14)+'│');
+    console.log('  ├'+'─'.repeat(16)+'┼'+'─'.repeat(14)+'┼'+'─'.repeat(14)+'┼'+'─'.repeat(18)+'┤');
+    for (const f of features) {
+      const ico = icon(f);
+      const sl = (ico+' '+(f.status==='pr-created'?'pr-created':f.status)).substring(0,12).padEnd(12);
+      const pl = (f.phase).substring(0,12).padEnd(12);
+      const tl = String(fmtTok(f.tokens)).padStart(14);
+      console.log('  │  '+pad(f.id,14)+'│  '+sl+'│  '+pl+'│  '+tl+'  │');
+    }
+    console.log('  └'+'─'.repeat(16)+'┴'+'─'.repeat(14)+'┴'+'─'.repeat(14)+'┴'+'─'.repeat(18)+'┘');
+  " 2>/dev/null || true
+}
+
 draw_progress_bar() {
   local current="$1"
   local total="$2"
@@ -53,7 +101,7 @@ draw_progress_bar() {
 }
 
 display_summary() {
-  local done_n="$1" pr_n="$2" ready_n="$3" failed_n="$4" total_time="$5" processed="$6"
+  local done_n="$1" pr_n="$2" ready_n="$3" failed_n="$4" total_time="$5" processed="$6" ran_n="${7:-$6}"
 
   echo ""
   echo "  ┌──────────────────────────────────────┐"
@@ -64,9 +112,11 @@ display_summary() {
   printf "  │  Ready:   %-26s │\n" "$ready_n"
   printf "  │  Failed:  %-26s │\n" "$failed_n"
   echo "  ├──────────────────────────────────────┤"
+  printf "  │  Ran this session: %-17s │\n" "$ran_n"
+  echo "  ├──────────────────────────────────────┤"
   printf "  │  Total:   %-26s │\n" "${total_time}s"
   local avg=0
-  [ "$processed" -gt 0 ] && avg=$((total_time / processed))
+  [ "${ran_n:-0}" -gt 0 ] && avg=$((total_time / ran_n))
   printf "  │  Avg:     %-26s │\n" "${avg}s/feature"
   echo "  └──────────────────────────────────────┘"
 }
@@ -89,4 +139,35 @@ display_routing() {
       console.log('    Task ' + t.task_id + ': ' + t.title.substring(0,35).padEnd(35) + ' -> ' + agent);
     });
   " 2>/dev/null || true
+}
+
+# display_next_steps <feat_id> <exit_code> <next_feat_id> <autonomy> [model] [adapter]
+# Prints an actionable "what next" box after each feature completes.
+display_next_steps() {
+  local feat_id="$1" exit_code="$2" next_feat="${3:-}" autonomy="${4:-full_auto}" model="${5:-}" _adapter="${6:-}"
+
+  local cmd="feature-marker-orchestrate run --autonomy $autonomy"
+  [ -n "$model" ] && [ "$model" != "default" ] && [ "$model" != "opusplan" ] && cmd="$cmd --model $model"
+
+  local W=62
+  local inner=$((W - 4))  # content width between "  │  " and "  │"
+
+  echo ""
+  if [ "$exit_code" -ne 0 ]; then
+    printf "  ⚠  %s exited with errors (code %s) — review log before continuing.\n" "$feat_id" "$exit_code"
+  fi
+  printf "  ┌%s┐\n" "$(printf '─%.0s' $(seq 1 $W))"
+  if [ -n "$next_feat" ]; then
+    printf "  │  %-*s│\n" "$inner" "$feat_id → done.  Next: $next_feat"
+    printf "  │  %-*s│\n" "$inner" ""
+    printf "  │  %-*s│\n" "$inner" "Continue with the same command:"
+    printf "  │  %-*s│\n" "$inner" ""
+    printf "  │    %-*s│\n" "$((inner - 2))" "$cmd"
+  else
+    printf "  │  %-*s│\n" "$inner" "All features complete."
+    printf "  │  %-*s│\n" "$inner" ""
+    printf "  │  %-*s│\n" "$inner" "Run: feature-marker-orchestrate status"
+  fi
+  printf "  └%s┘\n" "$(printf '─%.0s' $(seq 1 $W))"
+  echo ""
 }

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -840,23 +840,43 @@ run_pr_creation() {
   fi
 
   info "Creating PR for $feat_id..."
-  (
-    cd "$wt_path"
-    git add -A 2>/dev/null || true
-    git commit -m "feat: $title" --allow-empty >/dev/null 2>&1 || true
-    git push origin "${BRANCH_PREFIX:-feat}/$feat_id" >/dev/null 2>&1 || true
-  )
+  local branch="${BRANCH_PREFIX:-feat}/$feat_id"
+  local push_err="" push_exit=0
+
+  if [ -d "$wt_path" ]; then
+    local push_tmpfile
+    push_tmpfile=$(mktemp)
+    (
+      cd "$wt_path"
+      git add -A 2>/dev/null || true
+      git commit -m "feat: $title" --allow-empty 2>/dev/null || true
+      git push origin "$branch"
+    ) 2>"$push_tmpfile"
+    push_exit=$?
+    push_err=$(cat "$push_tmpfile")
+    rm -f "$push_tmpfile"
+  else
+    push_err="worktree $wt_path no longer exists (cleaned up before PR creation)"
+    push_exit=1
+  fi
 
   local pr_flag=""
   [ "$PR_STRATEGY" = "draft" ] && pr_flag="--draft"
 
-  local pr_url
-  pr_url=$(gh pr create --base "$BASE_BRANCH" --head "${BRANCH_PREFIX:-feat}/$feat_id" \
+  local pr_url="" pr_err="" pr_exit pr_tmpfile
+  pr_tmpfile=$(mktemp)
+  pr_url=$(gh pr create --base "$BASE_BRANCH" --head "$branch" \
     --title "feat: $title" \
     --body "Automated by feature-marker orchestrator." \
-    $pr_flag 2>/dev/null) || pr_url=""
+    $pr_flag 2>"$pr_tmpfile")
+  pr_exit=$?
+  pr_err=$(cat "$pr_tmpfile")
+  rm -f "$pr_tmpfile"
 
-  if [ -n "$pr_url" ]; then
+  # gh pr create may also surface the URL when an existing PR already matches
+  [ -z "$pr_url" ] && pr_url=$(echo "$pr_err" | grep -Eo 'https://github\.com/[^ ]+' | head -1)
+
+  if [ $pr_exit -eq 0 ] && [ -n "$pr_url" ]; then
     wt_update_status "$feat_id" "pr-created" "complete"
     node -e "const fs=require('fs');const r=JSON.parse(fs.readFileSync('$results_file','utf-8'));r.pr_url='$pr_url';r.pipeline.review={status:'completed',pr_url:'$pr_url'};fs.writeFileSync('$results_file',JSON.stringify(r,null,2));" 2>/dev/null || true
     info "PR: $pr_url"
@@ -866,7 +886,32 @@ run_pr_creation() {
     fi
   else
     wt_update_status "$feat_id" "done" "complete"
-    info "Done: $feat_id (PR creation failed — skipping)"
+    local W=64
+    local inner=$((W - 2))
+    echo ""
+    printf "  ┌%s┐\n" "$(printf '─%.0s' $(seq 1 $W))"
+    printf "  │  %-*s│\n" "$((inner - 2))" "PR creation failed: $feat_id"
+    printf "  ├%s┤\n" "$(printf '─%.0s' $(seq 1 $W))"
+    if [ $push_exit -ne 0 ] && [ -n "$push_err" ]; then
+      printf "  │  %-*s│\n" "$((inner - 2))" "git push $branch:"
+      while IFS= read -r line; do
+        printf "  │    %-*s│\n" "$((inner - 4))" "${line:0:$((inner - 4))}"
+      done <<< "$(echo "$push_err" | head -5)"
+    fi
+    if [ -n "$pr_err" ]; then
+      printf "  │  %-*s│\n" "$((inner - 2))" ""
+      printf "  │  %-*s│\n" "$((inner - 2))" "gh pr create:"
+      while IFS= read -r line; do
+        printf "  │    %-*s│\n" "$((inner - 4))" "${line:0:$((inner - 4))}"
+      done <<< "$(echo "$pr_err" | head -5)"
+    fi
+    printf "  ├%s┤\n" "$(printf '─%.0s' $(seq 1 $W))"
+    printf "  │  %-*s│\n" "$((inner - 2))" "To create manually:"
+    printf "  │    %-*s│\n" "$((inner - 4))" "git push origin $branch"
+    printf "  │    %-*s│\n" "$((inner - 4))" "gh pr create --base $BASE_BRANCH --head $branch \\"
+    printf "  │      %-*s│\n" "$((inner - 6))" "--title \"feat: $title\""
+    printf "  └%s┘\n" "$(printf '─%.0s' $(seq 1 $W))"
+    echo ""
   fi
 }
 

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -13,6 +13,44 @@
 #   - router_route_task() for stack-aware agent selection (router.sh)
 #   - cycle_gate_check() before advancing to next feature (cycle_gate.sh)
 
+# _orchestrator_watcher_start <sentinel> <watch_dir> [interval_s]
+# Launches a background heartbeat process that prints [progress] lines to stdout
+# every interval_s seconds. Tracks newly-written files under watch_dir by name.
+# PID stored at <sentinel>.pid so _orchestrator_watcher_stop can kill it.
+# Set PROGRESS_INTERVAL=0 to disable entirely.
+_orchestrator_watcher_start() {
+  local sentinel="$1" watch_dir="$2" interval="${3:-45}"
+  [ "${interval}" -le 0 ] 2>/dev/null && return 0
+  local ref="${sentinel}.ref" pid_file="${sentinel}.pid"
+  local start_ts
+  start_ts=$(date +%s)
+  touch "$sentinel" "$ref"
+  (
+    while [ -f "$sentinel" ]; do
+      sleep "$interval"
+      [ -f "$sentinel" ] || break
+      elapsed=$(( $(date +%s) - start_ts ))
+      changed=$(find "$watch_dir" -newer "$ref" -type f 2>/dev/null | sort | while IFS= read -r f; do basename "$f"; done | tr '\n' ' ')
+      touch "$ref"
+      if [ -n "$changed" ]; then
+        printf '  [progress] %ds elapsed — files written: %s\n' "$elapsed" "$changed"
+      else
+        printf '  [progress] %ds elapsed — Claude working (no new files in last %ds)\n' "$elapsed" "$interval"
+      fi
+    done
+  ) &
+  echo $! > "$pid_file"
+}
+
+# _orchestrator_watcher_stop <sentinel>
+# Removes the sentinel (stopping the watcher loop) and kills the background PID.
+_orchestrator_watcher_stop() {
+  local sentinel="$1" pid
+  pid=$(cat "${sentinel}.pid" 2>/dev/null || true)
+  rm -f "$sentinel" "${sentinel}.ref" "${sentinel}.pid"
+  [ -n "$pid" ] && { kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; }
+}
+
 run_backlog() {
   local backlog_file="$1"
   local start_time
@@ -81,6 +119,7 @@ run_backlog() {
   fi
 
   # Single-feature mode
+  local ran_count=0
   if [ -n "${OPT_FEATURE:-}" ]; then
     local single
     single=$(echo "$items" | node -e "
@@ -89,12 +128,23 @@ run_backlog() {
       if (f) console.log(JSON.stringify(f)); else process.exit(1);
     " 2>/dev/null) || { err "Feature $OPT_FEATURE not found in ready list"; return 1; }
     info "Single-feature mode: $OPT_FEATURE"
-    process_item "$single" 1 1
+    process_item "$single" 1 1 ""
+    ran_count=1
   else
     # Main loop — ADR-008: check hard-block deps + cycle gate per item
-    # ADR-010: process substitution replaces pipe so break/continue work in parent shell
+    # ADR-010: collect into array first so we can look ahead for next_feat_id
+    local item_list=()
+    while IFS= read -r _item_line; do
+      item_list+=("$_item_line")
+    done < <(echo "$items" | node -e "
+      const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+      d.ready.forEach(i => console.log(JSON.stringify(i)));
+    ")
+
     local index=0
-    while IFS= read -r item_json; do
+    local ran_count=0
+    for _i in "${!item_list[@]}"; do
+      local item_json="${item_list[$_i]}"
       index=$((index + 1))
 
       # ADR-008 PR-C: hard-block dependency check
@@ -110,21 +160,40 @@ run_backlog() {
         fi
       fi
 
-      process_item "$item_json" "$index" "$ready_count"
+      # Look ahead: ID of next item for "what next" guidance
+      local next_feat_id=""
+      local _next_i=$((_i + 1))
+      if [ "$_next_i" -lt "${#item_list[@]}" ]; then
+        next_feat_id=$(echo "${item_list[$_next_i]}" | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8')).id")
+      fi
+
+      # Track which features actually ran (vs skipped as already-done)
+      local _status_before
+      _status_before=$(wt_get_status "$feat_id_check")
+
+      process_item "$item_json" "$index" "$ready_count" "$next_feat_id"
+
+      if [ "$_status_before" != "done" ] && [ "$_status_before" != "pr-created" ]; then
+        ran_count=$((ran_count + 1))
+      fi
 
       # ADR-008 PR-D: cycle gate — assert previous feature completed full cycle
       if [ "${OPT_SKIP_CYCLE_CHECK:-false}" != "true" ]; then
         if ! cycle_gate_check "$feat_id_check"; then
-          info "Cycle gate: $feat_id_check did not complete full cycle"
           cycle_gate_report "$feat_id_check"
-          info "Use --skip-cycle-check to bypass. Stopping backlog loop."
+          echo ""
+          echo "  ⚠  Cycle gate: $feat_id_check did not complete a full cycle."
+          echo "     The feature has no merged PR or incomplete phase checkpoints."
+          echo "     Stopping to protect downstream features from running on a broken base."
+          echo ""
+          echo "     To skip the gate and continue anyway:"
+          local _gate_cmd="feature-marker-orchestrate run --autonomy ${AUTONOMY:-full_auto} --skip-cycle-check"
+          echo "       $_gate_cmd"
+          echo ""
           break
         fi
       fi
-    done < <(echo "$items" | node -e "
-      const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
-      d.ready.forEach(i => console.log(JSON.stringify(i)));
-    ")
+    done
   fi
 
   # Post-loop: cleanup
@@ -156,7 +225,7 @@ run_backlog() {
   done
 
   local processed=$((done_n + pr_n + ready_n + failed_n))
-  display_summary "$done_n" "$pr_n" "$ready_n" "$failed_n" "$total_time" "$processed"
+  display_summary "$done_n" "$pr_n" "$ready_n" "$failed_n" "$total_time" "$processed" "$ran_count"
 
   echo ""
   log "Per-feature:"
@@ -173,7 +242,7 @@ run_backlog() {
 }
 
 process_item() {
-  local item_json="$1" index="$2" total="$3"
+  local item_json="$1" index="$2" total="$3" next_feat_id="${4:-}"
 
   # Extract fields
   local feat_id title body priority labels deps
@@ -184,13 +253,14 @@ process_item() {
   labels=$(echo "$item_json" | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8')).labels.join(', ')")
   deps=$(echo "$item_json" | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8')).dependencies.join(', ')||'none'")
 
-  run_feature "$feat_id" "$title" "$body" "$priority" "$labels" "$deps" "$index" "$total"
+  run_feature "$feat_id" "$title" "$body" "$priority" "$labels" "$deps" "$index" "$total" "$next_feat_id"
 }
 
 run_feature() {
-  local feat_id="$1" title="$2" body="$3" priority="$4" labels="$5" deps="$6" index="$7" total="$8"
+  local feat_id="$1" title="$2" body="$3" priority="$4" labels="$5" deps="$6" index="$7" total="$8" next_feat_id="${9:-}"
 
   banner "[$index/$total] $feat_id: $title [$priority]"
+  display_backlog_table "$feat_id"
 
   # Skip if already completed
   local current
@@ -364,9 +434,22 @@ EOPRD
   fi
 
   info "Autonomy=$AUTONOMY — invoking pipeline (model: ${effective_model:-default}, agent: $skill_arg)..."
+  if [ "$AUTONOMY" = "full_auto" ]; then
+    echo "  [progress] Claude runs in batch (-p) mode — output is buffered until completion."
+    echo "             Monitor artifacts : $wt_path/tasks/prd-$feat_id/"
+    echo "             Monitor run log   : $log_file  (populates when Claude exits)"
+    echo ""
+    _orchestrator_watcher_start \
+      "$STATE_DIR/$feat_id/.watcher-active" \
+      "$wt_path/tasks/prd-$feat_id" \
+      "${PROGRESS_INTERVAL:-45}"
+  fi
+
   (cd "$wt_path" && op_timeout "${SKILL_TIMEOUT_SECONDS:-1800}" \
     claude ${effective_model:+--model "$effective_model"} --agent "$skill_arg" $perm_flag ${interactive_flag:+$interactive_flag} -p "prd-$feat_id") 2>&1 \
     | tee "$log_file" || exit_code=$?
+
+  _orchestrator_watcher_stop "$STATE_DIR/$feat_id/.watcher-active"
 
   # ── ADR-008 PR-A: Phase 3 scripted tests ────────────────────────
   # supervised handles tests interactively inside the Claude session; skip scripted runner.
@@ -477,7 +560,7 @@ EOPRD
   fi
 
   info "Feature time: ${duration}s"
-  echo ""
+  display_next_steps "$feat_id" "$exit_code" "$next_feat_id" "${AUTONOMY:-full_auto}" "${MODEL_DEFAULT:-}" "${ADAPTER:-}"
 }
 
 # ── run_phase3_tests ──────────────────────────────────────────────────
@@ -569,7 +652,14 @@ run_phase3_tests() {
 
     local fix_exit=0
     if command -v claude &>/dev/null; then
+      if [ "$AUTONOMY" = "full_auto" ]; then
+        _orchestrator_watcher_start \
+          "$STATE_DIR/$feat_id/.fix-watcher-active" \
+          "$wt_path" \
+          "${PROGRESS_INTERVAL:-45}"
+      fi
       (cd "$wt_path" && printf '%b' "$fix_prompt" | claude $model_flag $fix_perm_flag --print) 2>/dev/null || fix_exit=$?
+      _orchestrator_watcher_stop "$STATE_DIR/$feat_id/.fix-watcher-active"
     else
       info "Phase 3: Claude CLI not found — cannot attempt fix"
       return 1

--- a/tasks/prd-ux-orchestrator-progress/prd.md
+++ b/tasks/prd-ux-orchestrator-progress/prd.md
@@ -1,0 +1,37 @@
+# PRD: Orchestrator Progress & Guidance UX
+
+## Problem
+
+When `feature-marker-orchestrate run --autonomy full_auto` runs a backlog, operators face three distinct pain points:
+
+1. **Silent pipeline**: After `[orchestrate] Autonomy=full_auto — invoking pipeline…` nothing appears on screen for 5–15 minutes. Claude is working (files appear in the worktree) but the terminal looks frozen.
+
+2. **No "what next" instruction**: After a feature completes (e.g. feat-auth), the run ends showing 4 remaining "ready (awaiting-pipeline)" features but prints no command to continue. The operator doesn't know whether to re-run, wait, or do something else. The cycle-gate block is especially opaque — it says "Stopping backlog loop" with no actionable guidance.
+
+3. **Misleading summary stats**: The final `Orchestrator Summary` shows `Avg: 68s/feature` when only 1 feature ran in 344s. `processed` counts all features with state directories, not the ones that actually ran this invocation.
+
+## Goals
+
+1. **Eliminate "looks frozen" during Claude runs.** Operator should see meaningful progress every ≤ 45 seconds without needing to check a separate file.
+
+2. **Print an actionable "what next" block after every feature and at end-of-run.** Operator reads the terminal and knows exactly what command to run, or sees a clear "all done" confirmation.
+
+3. **Fix summary stat accuracy.** `Avg` and `Total` reflect only the features that ran in the current invocation.
+
+4. **Show full backlog status at phase transitions.** When a feature finishes and the next one starts, print a compact table showing all features and their statuses so the operator has a mental model of progress.
+
+## Non-Goals
+
+- A full TUI / ncurses dashboard (too fragile across terminal emulators)
+- Streaming Claude's internal token-by-token output (not available without stream-json mode change)
+- A web UI or external monitoring service
+- Changes to cycle-gate business logic (only messaging is in scope)
+
+## Success Criteria
+
+- After `invoking pipeline…` the operator sees at least one `[progress]` heartbeat within 45s (already implemented — this PRD ensures it's complete and consistent).
+- After every `[orchestrate] Done: feat-*` line, a "Next steps" block is printed.
+- The block includes the exact command to run next (or "all features complete").
+- When cycle-gate blocks, the printed command includes `--skip-cycle-check` with a one-line explanation.
+- `Avg` in the final summary equals `Total ÷ (features that ran this invocation)`, not total state-dir count.
+- At each feature-start banner, a compact backlog table is shown (id, status, phase, cost).

--- a/tasks/prd-ux-orchestrator-progress/tasks.md
+++ b/tasks/prd-ux-orchestrator-progress/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: Orchestrator Progress & Guidance UX
+
+## Task List
+
+- [ ] 1. Add `display_backlog_table()` to `display.sh`
+- [ ] 2. Call `display_backlog_table()` at each feature-start banner in `runner.sh`
+- [ ] 3. Add `display_next_steps()` to `display.sh`
+- [ ] 4. Thread `next_feat_id` from `run_backlog()` into `run_feature()` and call `display_next_steps()`
+- [ ] 5. Improve cycle-gate block messaging in `runner.sh`
+- [ ] 6. Fix `processed` count (introduce `ran_count`) in `run_backlog()`
+- [ ] 7. Add "Ran this session" row to `display_summary()` in `display.sh`
+- [ ] 8. Manual smoke test against stub-project
+
+## Task Details
+
+### Task 1 — `display_backlog_table()` in display.sh
+
+**File:** `scripts/lib/display.sh`
+
+Add after `display_backlog()`. Reads all `$STATE_DIR/*/status.json` and `$STATE_DIR/*/cost.json`. Prints the bordered table with columns: Feature (16), Status (12), Phase (14), Tokens (10). Status icons: `✓` done/pr-created, `→` in-progress, `✗` failed, `⏸` paused, `·` ready/pending/created. Tokens from `cost.json .cumulative_tokens`; show `—` if absent.
+
+Accept one optional argument: the currently-active feat_id, so it can mark that row `→ active` regardless of status.json (which may lag).
+
+### Task 2 — Call site in `runner.sh`
+
+**File:** `scripts/lib/runner.sh`, inside `run_feature()`, after the existing `banner "[$index/$total]..."` line (~line 232 post-watcher changes).
+
+```bash
+display_backlog_table "$feat_id"
+```
+
+### Task 3 — `display_next_steps()` in display.sh
+
+**File:** `scripts/lib/display.sh`
+
+Arguments: `current_feat_id`, `exit_code`, `next_feat_id` (empty = last), `autonomy`, `model` (optional, empty ok), `adapter` (optional, empty ok).
+
+- If `next_feat_id` is non-empty: print "Next feature" box with copy-paste re-run command
+- If `next_feat_id` is empty: print "All features complete" box
+- If `exit_code` != 0: prefix the box with a warning line about the failure
+
+### Task 4 — Thread next_feat_id and call display_next_steps
+
+**File:** `scripts/lib/runner.sh`
+
+In `run_backlog()`, after collecting the list of ready items, determine the next item for each index and pass it into `process_item()` / `run_feature()`. Add a 9th parameter `next_feat_id` to `run_feature()`.
+
+At the end of `run_feature()`, after `info "Feature time: ${duration}s"`:
+
+```bash
+display_next_steps "$feat_id" "$exit_code" "${next_feat_id:-}" "$AUTONOMY" "${MODEL_DEFAULT:-}" "$ADAPTER"
+```
+
+### Task 5 — Cycle-gate block messaging
+
+**File:** `scripts/lib/runner.sh`, the `cycle_gate_check` block (~line 155 pre-changes, will shift).
+
+Replace the two bare `info` lines with the expanded block from the techspec: warning box + copy-paste command including `--skip-cycle-check`.
+
+### Task 6 — Fix `ran_count` in `run_backlog()`
+
+**File:** `scripts/lib/runner.sh`, `run_backlog()`.
+
+Add `local ran_count=0`. Increment after each `process_item()` call where the item was not skipped (status not already done/pr-created). Pass as `processed` to `display_summary()`.
+
+### Task 7 — "Ran this session" row in `display_summary()`
+
+**File:** `scripts/lib/display.sh`, `display_summary()`.
+
+Add a 7th parameter `ran_n`. Insert row `│  Ran this session: %-26s │` between the Failed row and the separator. Callers: update the single call site in `run_backlog()`.
+
+### Task 8 — Smoke test
+
+Run `feature-marker-orchestrate run --autonomy full_auto` against `/Users/viniciuscarvalho/fm-validation/stub-project/`. Verify:
+
+- Backlog table appears at each feature-start banner
+- `[progress]` heartbeats fire every ~45s during Claude run
+- "Next steps" box with correct command appears after feat-auth
+- Final summary shows `Ran this session: 1` and `Avg: 344s/feature` (not 68s)

--- a/tasks/prd-ux-orchestrator-progress/techspec.md
+++ b/tasks/prd-ux-orchestrator-progress/techspec.md
@@ -1,0 +1,194 @@
+# TechSpec: Orchestrator Progress & Guidance UX
+
+## Architecture Overview
+
+All changes are confined to:
+
+- `scripts/lib/runner.sh` — run_backlog(), run_feature(), display_summary()
+- `scripts/lib/display.sh` — new display_backlog_table(), enhanced display_summary()
+- `scripts/orchestrate.sh` — cycle-gate messaging block
+
+No new files, no external dependencies, no changes to state file formats.
+
+---
+
+## Change 1: Backlog Status Table at Feature Start
+
+**Location:** `scripts/lib/display.sh` + called from `run_feature()` in `runner.sh`
+
+### New function: `display_backlog_table()`
+
+Reads all `$STATE_DIR/*/status.json` and `$STATE_DIR/*/cost.json` files and prints a compact table.
+
+```
+  ┌────────────────────────────────────────────────────────────────┐
+  │  BACKLOG  [2/5 done]  total ~134,000 tokens                   │
+  ├──────────────────┬──────────────┬──────────────┬──────────────┤
+  │  Feature         │  Status      │  Phase       │  Tokens      │
+  ├──────────────────┼──────────────┼──────────────┼──────────────┤
+  │  feat-auth       │  ✓ done      │  complete    │   67,000     │
+  │  feat-export     │  → active    │  impl.       │   25,000     │
+  │  feat-profile    │  · ready     │  pending     │       —      │
+  │  feat-search     │  · ready     │  pending     │       —      │
+  │  feat-settings   │  · ready     │  pending     │       —      │
+  └──────────────────┴──────────────┴──────────────┴──────────────┘
+```
+
+**Implementation:**
+
+- Pure bash + `node -p` (already used throughout the codebase) to read JSON
+- Column widths fixed (no dynamic sizing needed)
+- Status icons: `✓` done/pr-created, `→` in-progress, `✗` failed, `·` ready/pending, `⏸` paused
+- Tokens column: reads `cost.json` cumulative field; shows `—` if file absent
+- Called at the top of `run_feature()` after the `banner "[$index/$total]..."` line
+
+### Call site in `run_feature()` (`runner.sh` ~line 232):
+
+```bash
+banner "[$index/$total] $feat_id: $title [$priority]"
+display_backlog_table   # NEW — shows full backlog state before starting this feature
+```
+
+`display_backlog_table` needs `$STATE_DIR` — already exported globally.
+
+---
+
+## Change 2: "Next Steps" Block After Each Feature
+
+**Location:** end of `run_feature()` in `runner.sh`, after the `info "Feature time: ${duration}s"` line.
+
+### New function: `display_next_steps()` in `display.sh`
+
+Arguments: `feat_id` `exit_code` `next_feat_id` (empty string if last feature)
+
+```
+  ┌──────────────────────────────────────────────────────────────┐
+  │  feat-auth: DONE  (340s · 67,000 tokens)                     │
+  ├──────────────────────────────────────────────────────────────┤
+  │  Next feature: feat-export                                   │
+  │                                                              │
+  │  Re-run the same command to continue:                        │
+  │                                                              │
+  │    feature-marker-orchestrate run --autonomy full_auto       │
+  └──────────────────────────────────────────────────────────────┘
+```
+
+When no next feature (all done):
+
+```
+  ┌──────────────────────────────────────────────────────────────┐
+  │  All features complete.                                      │
+  │  Run `feature-marker-orchestrate status` to review results.  │
+  └──────────────────────────────────────────────────────────────┘
+```
+
+**Implementation:**
+
+- Reads `$STATE_DIR/*/status.json` to find the next non-done feature
+- Reconstructs the exact CLI invocation by reading `$AUTONOMY`, `$MODEL_DEFAULT`, `$ADAPTER`
+- Prints the command verbatim so operator can copy-paste
+
+### Call site in `run_feature()`:
+
+```bash
+info "Feature time: ${duration}s"
+display_next_steps "$feat_id" "$exit_code" "$next_feat_id"   # NEW
+```
+
+`next_feat_id` is the next item from the backlog loop — passed into `run_feature()` as a new optional 9th argument. If absent (last feature), `display_next_steps` prints the "all done" variant.
+
+---
+
+## Change 3: Cycle-Gate Block Messaging
+
+**Location:** `runner.sh` ~line 155, inside the cycle-gate check block.
+
+### Current code:
+
+```bash
+info "Cycle gate: $feat_id_check did not complete full cycle"
+cycle_gate_report "$feat_id_check"
+info "Use --skip-cycle-check to bypass. Stopping backlog loop."
+break
+```
+
+### New code:
+
+```bash
+info "Cycle gate: $feat_id_check did not complete full cycle"
+cycle_gate_report "$feat_id_check"
+echo ""
+echo "  ⚠  Cycle gate blocked advancement to the next feature."
+echo "     This happens when the previous feature has no merged PR or incomplete phases."
+echo ""
+echo "     To continue anyway:"
+echo "       feature-marker-orchestrate run --autonomy $AUTONOMY --skip-cycle-check"
+echo ""
+break
+```
+
+The existing `--skip-cycle-check` flag is already implemented — this just makes it discoverable.
+
+---
+
+## Change 4: Fix Summary `processed` Count
+
+**Location:** `runner.sh`, the code block that calls `display_summary()`.
+
+### Root cause:
+
+`processed` is calculated as `done_n + pr_n + ready_n + failed_n` — counting ALL features with state dirs. Should count only features that were in the backlog this invocation.
+
+### Fix:
+
+Track a `ran_count` counter inside `run_backlog()` that increments only when `process_item()` actually calls `run_feature()` (i.e., the feature was not skipped as already-done). Pass `ran_count` to `display_summary()` as the `processed` argument instead of the current aggregate.
+
+**In `run_backlog()`:**
+
+```bash
+local ran_count=0
+
+# Inside the loop, after process_item():
+ran_count=$((ran_count + 1))
+
+# At summary:
+display_summary "$done_n" "$pr_n" "$ready_n" "$failed_n" "$total_time" "$ran_count"
+```
+
+Skipped features (already done/pr-created) do NOT increment `ran_count`.
+
+---
+
+## Change 5: Enhanced `display_summary()` Column
+
+**Location:** `display.sh`, `display_summary()`.
+
+Add a "Ran this session" row between the counts and the timing:
+
+```
+  │  Ran this session: 1                     │
+```
+
+This makes it unambiguous that `Avg` refers only to features processed in this run.
+
+---
+
+## Data Dependencies
+
+| What                      | Source                                          | Already exists?  |
+| ------------------------- | ----------------------------------------------- | ---------------- |
+| Feature status            | `$STATE_DIR/$id/status.json`                    | Yes              |
+| Cumulative tokens         | `$STATE_DIR/$id/cost.json` `.cumulative_tokens` | Yes              |
+| Next feature ID           | Backlog JSON, passed from `run_backlog()`       | Needs threading  |
+| Run invocation flags      | `$AUTONOMY`, `$MODEL_DEFAULT`, `$ADAPTER`       | Exported globals |
+| Features ran this session | New `ran_count` local in `run_backlog()`        | New              |
+
+---
+
+## Testing
+
+1. Run stub-project with 5 features in full_auto → verify backlog table appears at each feature start
+2. Kill run mid-backlog → re-run → verify "next steps" block shows correct next feature
+3. Force cycle-gate block → verify new messaging with copy-paste command appears
+4. Single-feature run (1 feature done, 0 remaining) → verify "all features complete" block
+5. `Avg` = `Total ÷ ran_count` for any subset of features processed


### PR DESCRIPTION
## Summary

- **Backlog table at every feature start** — `display_backlog_table()` prints a live bordered table before each feature runs, showing all features with status icons (✓/→/✗/⏸/·), current phase, and cumulative token cost. No more guessing where you are in the backlog.

- **Actionable "what next" box after every feature** — `display_next_steps()` prints the exact copy-paste command to continue after each feature. When the cycle gate blocks, the box includes `--skip-cycle-check` with a plain-English explanation — previously this was a bare `info` line with no guidance.

- **Fixed summary Avg/Total accuracy** — `run_backlog()` now tracks `ran_count` (features that actually ran this invocation) separately from the state-dir count. `display_summary()` gains a `ran_n` 7th param (backward compatible). Fixes `68s/feature` average when only 1 of 5 features ran.

- **Diagnostic box on PR creation failure** — `run_pr_creation()` was silently swallowing all errors. Now captures git push and gh pr create stderr separately, detects missing worktrees (cleaned up by AUTO_CLEANUP), and prints an actionable box with the actual error lines and copy-paste commands to recover manually.

- **CHANGELOG correction** — PR #43 entry was inverted (claimed `--dangerously-skip-permissions` was added; actually it was replaced by `--permission-mode bypassPermissions`).

## Implementation details

- `display.sh`: added `display_backlog_table()` and `display_next_steps()`; `display_summary()` 7th arg `ran_n` defaults to `processed` for backward compat
- `runner.sh`: while-read loop converted to array loop for look-ahead; `next_feat_id` threaded through `process_item → run_feature`; cycle-gate block replaced with explanatory box + copy-paste command; `run_pr_creation()` now captures stderr via mktemp, handles missing worktrees, and prints a diagnostic box on failure
- No new external dependencies; no state file format changes

## Test plan

- [ ] Run stub-project with 5 features in `full_auto` — verify backlog table appears at each feature-start banner
- [ ] Verify `[progress]` heartbeat fires every ~45s during Claude invocation
- [ ] Verify "Next steps" box with correct command appears after first feature completes
- [ ] Force cycle-gate block — verify new messaging with `--skip-cycle-check` appears
- [ ] Single-feature run — verify "All features complete" variant
- [ ] Confirm `Ran this session: 1` and `Avg: 344s/feature` in summary (not 68s)
- [ ] Trigger PR creation with cleaned-up worktree — verify diagnostic box names the missing path
- [ ] Trigger PR creation with `git push` auth error — verify stderr appears in the box
- [ ] Trigger PR creation on branch that already has an open PR — verify URL is extracted from stderr and run succeeds
