### PR TITLE
chore: release v7.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.7.0] - 2026-04-21
+
+### Added
+
+- **Live backlog table in orchestrator progress view** (PR #46) — The UX orchestrator now renders a live-updating table of the feature backlog during a run, giving operators real-time visibility into which tasks are queued, in-progress, and done
+- **Next-steps guidance after a run** (PR #46) — After each orchestrator cycle completes, the UX layer surfaces a curated next-steps panel so operators know exactly what action to take (e.g. review PR, approve checkpoint, retry failed task) without scanning raw logs
+- **Summary accuracy improvements** (PR #46) — Orchestrator run summaries now reflect the actual terminal state of each task rather than the last known state, eliminating stale "in-progress" entries in post-run reports
+
+### Fixed
+
+- **Git push and `gh pr create` errors surfaced on PR creation failure** (PR #46) — When the orchestrator's automated PR creation step fails (network error, branch protection, quota limit, etc.) the underlying `git push` or `gh pr create` stderr is now captured and shown to the operator instead of a generic "PR creation failed" message
+
 ## [7.6.0] - 2026-04-21
 
 ### Added

--- a/homebrew/feature-marker.rb
+++ b/homebrew/feature-marker.rb
@@ -6,9 +6,9 @@
 class FeatureMarker < Formula
   desc "AI-powered feature development automation — skill + orchestrator"
   homepage "https://github.com/Viniciuscarvalho/Feature-marker"
-  url "https://github.com/Viniciuscarvalho/Feature-marker/archive/refs/tags/v7.6.0.tar.gz"
-  sha256 "df1723649c1caa48ec7d7aee7b0d47d6f2a79b3cbd0cd8bfd282cac2f4de8d9e"
-  version "7.6.0"
+  url "https://github.com/Viniciuscarvalho/Feature-marker/archive/refs/tags/v7.7.0.tar.gz"
+  sha256 "PLACEHOLDER"
+  version "7.7.0"
   license "MIT"
   head "https://github.com/Viniciuscarvalho/Feature-marker.git", branch: "main"
 


### PR DESCRIPTION
## Summary

- Adds CHANGELOG entry for v7.7.0 covering the UX orchestrator progress improvements merged in PR #46
- Bumps Homebrew formula to v7.7.0 (SHA256 placeholder — will be updated after tag is pushed and tarball is generated)

## Changes in v7.7.0 (PR #46)

### Added

- Live backlog table in orchestrator progress view
- Next-steps guidance panel after each orchestrator cycle
- Summary accuracy improvements (reflects actual terminal task state)

### Fixed

- Git push and `gh pr create` errors now surfaced on PR creation failure instead of a generic message

## After merging

1. Merge this PR
2. Create and push tag: `git tag v7.7.0 && git push origin v7.7.0`
3. Create GitHub release for v7.7.0
4. Get SHA256 of the tarball and update formula in a follow-up Homebrew tap PR

## Test plan

- [ ] CHANGELOG renders correctly with v7.7.0 at the top
- [ ] Formula version string is 7.7.0
- [ ] After tagging, tarball is accessible at the expected URL
