### PR TITLE
feat(learning): Ralph Loop always-learn + pause-on-exhaustion

### DIFF
--- a/scripts/lib/display.sh
+++ b/scripts/lib/display.sh
@@ -101,7 +101,7 @@ draw_progress_bar() {
 }
 
 display_summary() {
-  local done_n="$1" pr_n="$2" ready_n="$3" failed_n="$4" total_time="$5" processed="$6" ran_n="${7:-$6}"
+  local done_n="$1" pr_n="$2" ready_n="$3" failed_n="$4" total_time="$5" processed="$6" ran_n="${7:-$6}" paused_n="${8:-0}"
 
   echo ""
   echo "  ┌──────────────────────────────────────┐"
@@ -111,6 +111,7 @@ display_summary() {
   printf "  │  PR:      %-26s │\n" "$pr_n"
   printf "  │  Ready:   %-26s │\n" "$ready_n"
   printf "  │  Failed:  %-26s │\n" "$failed_n"
+  printf "  │  Paused:  %-26s │\n" "$paused_n"
   echo "  ├──────────────────────────────────────┤"
   printf "  │  Ran this session: %-17s │\n" "$ran_n"
   echo "  ├──────────────────────────────────────┤"
@@ -119,6 +120,32 @@ display_summary() {
   [ "${ran_n:-0}" -gt 0 ] && avg=$((total_time / ran_n))
   printf "  │  Avg:     %-26s │\n" "${avg}s/feature"
   echo "  └──────────────────────────────────────┘"
+}
+
+# display_paused_handoff <feat_id> <attempts> [pause_reason_path]
+# Prints a plain-text guidance block when Phase 3 is exhausted.
+# PR B upgrades this to a boxed ANSI variant.
+display_paused_handoff() {
+  local feat_id="$1" attempts="$2" pause_reason_path="${3:-}"
+
+  local resume_cmd="feature-marker-orchestrate --resume-paused $feat_id --ack"
+  local trail_path=""
+  if [ -n "$pause_reason_path" ] && [ -f "$pause_reason_path" ]; then
+    trail_path=$(node -p "
+      try { JSON.parse(require('fs').readFileSync('$pause_reason_path','utf-8')).trail_path || ''; }
+      catch(e) { ''; }
+    " 2>/dev/null || echo "")
+  fi
+
+  echo ""
+  echo "  ⏸  $feat_id — Phase 3 paused after $attempts fix attempt(s)"
+  echo "     Tests still failing. Review the attempt trail and fix manually."
+  echo ""
+  [ -n "$trail_path" ] && echo "     Trail: $trail_path"
+  echo "     Resume: $resume_cmd"
+  echo ""
+  echo "     Backlog continues with the next ready feature."
+  echo ""
 }
 
 display_routing() {

--- a/scripts/lib/learning.sh
+++ b/scripts/lib/learning.sh
@@ -40,7 +40,7 @@ _learning_ensure_file() {
   local dir
   dir=$(dirname "$path")
   mkdir -p "$dir"
-  [ ! -f "$path" ] && echo '[]' > "$path"
+  [ -f "$path" ] || echo '[]' > "$path"
 }
 
 # Path to the embedding sidecar file alongside a learned.json store.
@@ -309,16 +309,16 @@ learning_verify() {
   local success="$2"
   local tier_path="$3"
 
-  [ ! -f "$tier_path" ] && return
+  [ -f "$tier_path" ] || return 0
 
   node -e "
     const fs = require('fs');
     const path = '$tier_path';
     let entries;
-    try { entries = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch(e) { return; }
+    try { entries = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch(e) { process.exit(0); }
 
     const e = entries.find(e => e.id === '$learn_id');
-    if (!e) return;
+    if (!e) process.exit(0);
 
     if ('$success' === 'true') {
       e.success_count = (e.success_count || 0) + 1;

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -119,7 +119,7 @@ run_backlog() {
   fi
 
   # Single-feature mode
-  local ran_count=0
+  local ran_count=0 paused_count=0
   if [ -n "${OPT_FEATURE:-}" ]; then
     local single
     single=$(echo "$items" | node -e "
@@ -142,7 +142,6 @@ run_backlog() {
     ")
 
     local index=0
-    local ran_count=0
     for _i in "${!item_list[@]}"; do
       local item_json="${item_list[$_i]}"
       index=$((index + 1))
@@ -171,10 +170,16 @@ run_backlog() {
       local _status_before
       _status_before=$(wt_get_status "$feat_id_check")
 
-      process_item "$item_json" "$index" "$ready_count" "$next_feat_id"
+      local _pi_exit=0
+      process_item "$item_json" "$index" "$ready_count" "$next_feat_id" || _pi_exit=$?
 
       if [ "$_status_before" != "done" ] && [ "$_status_before" != "pr-created" ]; then
         ran_count=$((ran_count + 1))
+      fi
+
+      # exit 2 = phase3-paused; backlog continues to next feature
+      if [ "$_pi_exit" -eq 2 ]; then
+        paused_count=$((paused_count + 1))
       fi
 
       # ADR-008 PR-D: cycle gate — assert previous feature completed full cycle
@@ -208,7 +213,7 @@ run_backlog() {
   end_time=$(date +%s)
   local total_time=$((end_time - start_time))
 
-  local done_n=0 pr_n=0 ready_n=0 failed_n=0
+  local done_n=0 pr_n=0 ready_n=0 failed_n=0 paused_n=0
   for dir in "$STATE_DIR"/*/; do
     [ -d "$dir" ] || continue
     local fid
@@ -221,11 +226,12 @@ run_backlog() {
       pr-created) pr_n=$((pr_n+1)) ;;
       ready) ready_n=$((ready_n+1)) ;;
       failed) failed_n=$((failed_n+1)) ;;
+      paused) paused_n=$((paused_n+1)) ;;
     esac
   done
 
-  local processed=$((done_n + pr_n + ready_n + failed_n))
-  display_summary "$done_n" "$pr_n" "$ready_n" "$failed_n" "$total_time" "$processed" "$ran_count"
+  local processed=$((done_n + pr_n + ready_n + failed_n + paused_n))
+  display_summary "$done_n" "$pr_n" "$ready_n" "$failed_n" "$total_time" "$processed" "$ran_count" "$paused_n"
 
   echo ""
   log "Per-feature:"
@@ -477,7 +483,7 @@ EOPRD
     node -e "
       require('fs').writeFileSync('$results_file', JSON.stringify({
         feature_id: '$feat_id',
-        status: $exit_code === 0 ? 'completed' : ($exit_code === 10 ? 'paused' : 'failed'),
+        status: $exit_code === 0 ? 'completed' : ($exit_code === 2 || $exit_code === 10 ? 'paused' : 'failed'),
         title: $(printf '%s' "$title" | node -p "JSON.stringify(require('fs').readFileSync('/dev/stdin','utf-8').trim())"),
         pipeline: { prd: { status: 'completed' }, techspec: { status: 'pending' }, tasks: { status: 'pending' }, implementation: { status: 'pending' }, tests: { status: 'pending' }, review: { status: 'pending' } },
         context_generated: { files_created: [], files_modified: [], schema_changes: [], new_dependencies: [], breaking_changes: [] },
@@ -517,6 +523,9 @@ EOPRD
       wt_update_status "$feat_id" "done" "complete"
       info "Done: $feat_id (supervised)"
     fi
+  elif [ "$exit_code" -eq 2 ]; then
+    # Phase 3 exhausted — status/pause record already written by run_phase3_tests
+    info "Paused: $feat_id (phase3-exhausted)"
   elif [ "$exit_code" -eq 10 ]; then
     wt_update_status "$feat_id" "paused" "awaiting-review"
     _runner_record_pause "$feat_id" "human" "supervised-checkpoint"
@@ -566,10 +575,14 @@ EOPRD
 # ── run_phase3_tests ──────────────────────────────────────────────────
 # ADR-008 PR-A: Scripted test runner for Phase 3.
 # Detects stack, runs the appropriate test command.
-# On failure, invokes Claude for a fix (max 2 attempts).
-# Captures successful fixes to the learning store.
+# On failure, invokes Claude for a fix (up to max_fix_attempts).
+# Learning store integration:
+#   - Successful fix: learning_write (success) + learning_verify "true" on retrieved hint
+#   - Failed attempt: learning_write (failure marker) + learning_verify "false" on retrieved hint
+#   - Cross-attempt trail: accumulated in phase3-attempts.log, prepended to fix_prompt
+# On exhaustion: feature is paused (exit 2); run_backlog continues to next feature.
 # Writes fix attempt count to $STATE_DIR/$feat_id/phase3-fix-attempts.
-# Returns 0 on success (tests pass), 1 on persistent failure.
+# Returns 0 on success, 1 on unrecoverable error, 2 on exhaustion (paused).
 
 run_phase3_tests() {
   local feat_id="$1"
@@ -577,6 +590,8 @@ run_phase3_tests() {
 
   local fix_attempts=0
   echo "$fix_attempts" > "$STATE_DIR/$feat_id/phase3-fix-attempts"
+  # Reset attempt trail for this run
+  rm -f "$STATE_DIR/$feat_id/phase3-attempts.log"
 
   # Detect stack from worktree
   local wt_file_paths
@@ -620,24 +635,36 @@ run_phase3_tests() {
     info "Phase 3: Ralph Loop active — up to $max_fix_attempts fix attempts (full_auto)"
   fi
 
+  local trail_file="$STATE_DIR/$feat_id/phase3-attempts.log"
+
   while [ "$fix_attempts" -lt "$max_fix_attempts" ]; do
     fix_attempts=$((fix_attempts + 1))
     echo "$fix_attempts" > "$STATE_DIR/$feat_id/phase3-fix-attempts"
 
     info "Phase 3: fix attempt $fix_attempts/$max_fix_attempts"
 
-    # ADR-008 PR-C: check learning store for a known fix
+    # Compute error signature from current test output
     local error_sig
     error_sig=$(echo "$test_output" | head -5 | tr '\n' ' ' | sed 's/  */ /g')
-    local learned_fix
+
+    # Check learning store for a known fix; track the entry ID for later verification
+    local learned_fix used_learn_id=""
     learned_fix=$(learning_read "$feat_id" "$error_sig")
 
+    # Build fix prompt; prepend cross-attempt trail from attempt 2 onward (capped at last 3)
     local fix_prompt="Fix the failing tests. Test output:\n$test_output"
+    if [ "$fix_attempts" -gt 1 ] && [ -f "$trail_file" ]; then
+      local trail_content
+      trail_content=$(tail -c 2000 "$trail_file")
+      fix_prompt="Previous fix attempts for context:\n$trail_content\n\nCurrent failing tests:\n$test_output"
+    fi
+
     if [ -n "$learned_fix" ] && [ "$learned_fix" != "null" ]; then
       local hint
       hint=$(echo "$learned_fix" | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8')).fix" 2>/dev/null || echo "")
+      used_learn_id=$(echo "$learned_fix" | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8')).id" 2>/dev/null || echo "")
       if [ -n "$hint" ]; then
-        info "Phase 3: applying learned fix hint"
+        info "Phase 3: applying learned fix hint (id: $used_learn_id)"
         fix_prompt="$fix_prompt\n\nKnown fix hint: $hint"
       fi
     fi
@@ -665,19 +692,25 @@ run_phase3_tests() {
       return 1
     fi
 
-    # Re-run tests
+    # Re-run tests after fix attempt
     test_exit=0
     (cd "$wt_path" && eval "$test_cmd" >/tmp/phase3-test-output-$$.txt 2>&1) || test_exit=$?
 
     if [ "$test_exit" -eq 0 ]; then
       info "Phase 3: tests passed after fix attempt $fix_attempts"
 
-      # ADR-008 PR-C: capture successful fix to learning store
+      # Verify retrieved hint was useful
+      if [ -n "$used_learn_id" ]; then
+        local _vpath="$ROOT_DIR/.claude/feature-state/learned.json"
+        [ -f "$_vpath" ] && learning_verify "$used_learn_id" "true" "$_vpath"
+      fi
+
+      # Capture successful fix to learning store
       local fix_description
       fix_description=$(printf '%b' "$fix_prompt" | head -3 | tr '\n' ' ')
       learning_write "$feat_id" "$error_sig" "$fix_description"
 
-      # Verify the learning entry
+      # Verify the entry was written (idempotent verify on the new/updated entry)
       local project_path
       project_path="$ROOT_DIR/.claude/feature-state/learned.json"
       if [ -f "$project_path" ]; then
@@ -696,13 +729,60 @@ run_phase3_tests() {
       return 0
     fi
 
+    # Fix attempt failed — capture and learn from it
+    local prev_test_output="$test_output"
     test_output=$(cat /tmp/phase3-test-output-$$.txt 2>/dev/null || echo "test output unavailable")
     rm -f /tmp/phase3-test-output-$$.txt
+
+    # Verify retrieved hint was not useful (decay its confidence)
+    if [ -n "$used_learn_id" ]; then
+      local _vpath_fail="$ROOT_DIR/.claude/feature-state/learned.json"
+      [ -f "$_vpath_fail" ] && learning_verify "$used_learn_id" "false" "$_vpath_fail"
+    fi
+
+    # Write failure fingerprint to learning store so future runs know this was tried
+    local fix_desc_short post_error_sig
+    fix_desc_short=$(printf '%b' "$fix_prompt" | head -1 | cut -c1-120)
+    post_error_sig=$(echo "$test_output" | head -3 | tr '\n' ' ' | sed 's/  */ /g')
+    learning_write "$feat_id" "$error_sig" "FAILED[attempt $fix_attempts]: $fix_desc_short | result: $post_error_sig"
+
+    # Append stanza to cross-attempt trail (capped: keep only last 3 attempts worth)
+    {
+      echo "=== Attempt $fix_attempts/$max_fix_attempts ==="
+      echo "Error: $error_sig"
+      echo "Fix tried: $fix_desc_short"
+      echo "Result: $post_error_sig"
+      echo ""
+    } >> "$trail_file"
+    # Trim to last 3 stanzas (~60 lines) to keep prompt size bounded
+    if [ "$(wc -l < "$trail_file" 2>/dev/null || echo 0)" -gt 60 ]; then
+      tail -60 "$trail_file" > "${trail_file}.tmp" && mv "${trail_file}.tmp" "$trail_file"
+    fi
+
     mem_record_error "$feat_id" "phase3" "fix attempt $fix_attempts failed: $test_cmd"
   done
 
-  err "Phase 3: tests still failing after $max_fix_attempts fix attempts"
-  return 1
+  # All fix attempts exhausted — pause the feature so the backlog can continue
+  err "Phase 3: tests still failing after $max_fix_attempts fix attempts — pausing $feat_id"
+  wt_update_status "$feat_id" "paused" "phase3-exhausted"
+  _runner_record_pause "$feat_id" "human" "phase3-exhausted"
+
+  local last_error_sig
+  last_error_sig=$(echo "$test_output" | head -5 | tr '\n' ' ' | sed 's/  */ /g')
+  node -e "
+    const fs = require('fs');
+    const data = {
+      reason: 'phase3-exhausted',
+      attempts: $fix_attempts,
+      last_error_sig: $(node -p "JSON.stringify('$last_error_sig')" 2>/dev/null || echo '""'),
+      trail_path: '$trail_file',
+      paused_at: new Date().toISOString()
+    };
+    fs.writeFileSync('$STATE_DIR/$feat_id/pause-reason.json', JSON.stringify(data, null, 2));
+  " 2>/dev/null || true
+
+  display_paused_handoff "$feat_id" "$fix_attempts" "$STATE_DIR/$feat_id/pause-reason.json"
+  return 2
 }
 
 # ── dep_check_merge_state ─────────────────────────────────────────────

--- a/tests/lib/phase3_pause.bats
+++ b/tests/lib/phase3_pause.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# tests/lib/phase3_pause.bats — Tests for Phase 3 pause-on-exhaustion and display helpers.
+#
+# Tests display_paused_handoff and the paused_n row in display_summary.
+# Does not invoke run_phase3_tests directly (too many orchestrator dependencies).
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  export STATE_DIR="$TEST_TMP/state"
+  mkdir -p "$STATE_DIR/feat-test"
+
+  # Stub helpers display.sh needs
+  info() { :; }
+  log()  { :; }
+  wt_get_status() { echo "paused"; }
+  export -f info log wt_get_status
+
+  source "$REPO_ROOT/scripts/lib/display.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+# ── display_paused_handoff ─────────────────────────────────────────────
+
+@test "display_paused_handoff prints feature id and attempt count" {
+  run display_paused_handoff "feat-test" 5 ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"feat-test"* ]]
+  [[ "$output" == *"5 fix attempt"* ]]
+}
+
+@test "display_paused_handoff prints resume command" {
+  run display_paused_handoff "feat-auth" 3 ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--resume-paused feat-auth"* ]]
+}
+
+@test "display_paused_handoff shows trail path when pause-reason.json present" {
+  local pause_file="$TEST_TMP/pause-reason.json"
+  echo '{"reason":"phase3-exhausted","attempts":3,"trail_path":"/tmp/trail.log"}' > "$pause_file"
+
+  run display_paused_handoff "feat-auth" 3 "$pause_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"/tmp/trail.log"* ]]
+}
+
+@test "display_paused_handoff is silent about trail when pause-reason.json absent" {
+  run display_paused_handoff "feat-auth" 2 "/nonexistent/path.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Trail:"* ]]
+}
+
+# ── display_summary with paused_n ──────────────────────────────────────
+
+@test "display_summary shows Paused row when paused_n is non-zero" {
+  run display_summary 2 1 3 0 120 6 2 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Paused:"*"1"* ]]
+}
+
+@test "display_summary shows Paused row as 0 when 8th arg omitted" {
+  run display_summary 2 1 3 0 120 6 2
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Paused:"*"0"* ]]
+}
+
+@test "display_summary Avg uses ran_n not paused_n" {
+  # 2 ran in 200s → avg 100s/feature; paused_n should not affect divisor
+  run display_summary 1 1 0 0 200 3 2 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"100s/feature"* ]]
+}
+
+# ── pause-reason.json structure ────────────────────────────────────────
+
+@test "pause-reason.json written by orchestrator has required keys" {
+  # Simulate what run_phase3_tests writes
+  local pause_file="$TEST_TMP/pause-reason.json"
+  node -e "
+    const fs = require('fs');
+    const data = {
+      reason: 'phase3-exhausted',
+      attempts: 3,
+      last_error_sig: 'error: build failed',
+      trail_path: '$TEST_TMP/phase3-attempts.log',
+      paused_at: new Date().toISOString()
+    };
+    fs.writeFileSync('$pause_file', JSON.stringify(data, null, 2));
+  "
+
+  local reason attempts trail
+  reason=$(node -p "JSON.parse(require('fs').readFileSync('$pause_file','utf-8')).reason")
+  attempts=$(node -p "JSON.parse(require('fs').readFileSync('$pause_file','utf-8')).attempts")
+  trail=$(node -p "JSON.parse(require('fs').readFileSync('$pause_file','utf-8')).trail_path")
+
+  [ "$reason" = "phase3-exhausted" ]
+  [ "$attempts" = "3" ]
+  [[ "$trail" == *"phase3-attempts.log"* ]]
+}

--- a/tests/lib/ralph_loop_trail.bats
+++ b/tests/lib/ralph_loop_trail.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# tests/lib/ralph_loop_trail.bats — Tests for Phase 3 cross-attempt trail accumulation.
+#
+# Tests the trail file format and that learning_write is called with failure markers.
+# Sources learning.sh directly; does not invoke run_phase3_tests (too many deps).
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  export STATE_DIR="$TEST_TMP/state"
+  export ROOT_DIR="$TEST_TMP"
+  mkdir -p "$STATE_DIR/feat-test"
+  mkdir -p "$ROOT_DIR/.claude/feature-state"
+
+  info() { :; }
+  log()  { :; }
+  export -f info log
+
+  source "$REPO_ROOT/scripts/lib/learning.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+# ── attempt trail file format ──────────────────────────────────────────
+
+@test "trail file accumulates one stanza per failed attempt" {
+  local trail="$STATE_DIR/feat-test/phase3-attempts.log"
+
+  # Simulate two failed attempts writing to the trail
+  for attempt in 1 2; do
+    {
+      echo "=== Attempt $attempt/5 ==="
+      echo "Error: test output $attempt"
+      echo "Fix tried: fix attempt $attempt"
+      echo "Result: still broken"
+      echo ""
+    } >> "$trail"
+  done
+
+  local stanza_count
+  stanza_count=$(grep -c "^=== Attempt" "$trail")
+  [ "$stanza_count" -eq 2 ]
+}
+
+@test "trail file header includes attempt number and max" {
+  local trail="$STATE_DIR/feat-test/phase3-attempts.log"
+  {
+    echo "=== Attempt 1/5 ==="
+    echo "Error: something broke"
+    echo "Fix tried: tried to fix it"
+    echo "Result: still broken"
+    echo ""
+  } >> "$trail"
+
+  grep -q "=== Attempt 1/5 ===" "$trail"
+}
+
+@test "trail trim keeps file under 60 lines after overflow" {
+  local trail="$STATE_DIR/feat-test/phase3-attempts.log"
+
+  # Write 70 lines to the trail
+  for i in $(seq 1 14); do
+    {
+      echo "=== Attempt $i/20 ==="
+      echo "Error: error $i"
+      echo "Fix tried: fix $i"
+      echo "Result: failed $i"
+      echo ""
+    } >> "$trail"
+  done
+
+  # Simulate the trim logic from run_phase3_tests
+  if [ "$(wc -l < "$trail")" -gt 60 ]; then
+    tail -60 "$trail" > "${trail}.tmp" && mv "${trail}.tmp" "$trail"
+  fi
+
+  local line_count
+  line_count=$(wc -l < "$trail")
+  [ "$line_count" -le 60 ]
+}
+
+# ── learning_write failure marker ──────────────────────────────────────
+# Note: do not pre-create learned.json — _learning_ensure_file exits non-zero
+# when the file already exists ([ ! -f ] && echo pattern). Let learning_write
+# create it fresh from an empty state directory.
+
+@test "learning_write records FAILED marker in project store" {
+  local project_path="$ROOT_DIR/.claude/feature-state/learned.json"
+
+  local error_sig="error: test failed line 42"
+  learning_write "feat-test" "$error_sig" "FAILED[attempt 1]: tried fix A | result: still failing"
+
+  local recorded_fix
+  recorded_fix=$(node -p "
+    const e = JSON.parse(require('fs').readFileSync('$project_path','utf-8'));
+    const m = e.find(x => x.pattern === '$error_sig');
+    m ? m.fix : 'NOT_FOUND';
+  ")
+
+  [[ "$recorded_fix" == FAILED* ]]
+}
+
+@test "learning_write updates existing entry on second failed attempt" {
+  local project_path="$ROOT_DIR/.claude/feature-state/learned.json"
+
+  local error_sig="error: recurring failure"
+  learning_write "feat-test" "$error_sig" "FAILED[attempt 1]: fix A"
+  learning_write "feat-test" "$error_sig" "FAILED[attempt 2]: fix B"
+
+  local entry_count
+  entry_count=$(node -p "
+    JSON.parse(require('fs').readFileSync('$project_path','utf-8'))
+      .filter(e => e.pattern === '$error_sig').length
+  ")
+  [ "$entry_count" -eq 1 ]
+
+  local hits
+  hits=$(node -p "
+    const e = JSON.parse(require('fs').readFileSync('$project_path','utf-8'));
+    const m = e.find(x => x.pattern === '$error_sig');
+    m ? m.hits : 0;
+  ")
+  [ "$hits" -eq 2 ]
+}
+
+# ── learning_verify confidence decay ──────────────────────────────────
+
+@test "learning_verify false decreases confidence after repeated failures" {
+  local project_path="$ROOT_DIR/.claude/feature-state/learned.json"
+
+  learning_write "feat-test" "error pattern" "some fix"
+  local learn_id
+  learn_id=$(node -p "
+    JSON.parse(require('fs').readFileSync('$project_path','utf-8'))[0].id
+  ")
+
+  learning_verify "$learn_id" "false" "$project_path"
+  learning_verify "$learn_id" "false" "$project_path"
+  learning_verify "$learn_id" "false" "$project_path"
+
+  local confidence
+  confidence=$(node -p "
+    const e = JSON.parse(require('fs').readFileSync('$project_path','utf-8'));
+    const m = e.find(x => x.id === '$learn_id');
+    m ? m.confidence : -1;
+  ")
+
+  # 0 successes, 3 failures → confidence = 0
+  [ "$confidence" = "0" ]
+}
+
+@test "learning_verify true increases confidence" {
+  local project_path="$ROOT_DIR/.claude/feature-state/learned.json"
+
+  learning_write "feat-test" "error pattern" "some fix"
+  local learn_id
+  learn_id=$(node -p "
+    JSON.parse(require('fs').readFileSync('$project_path','utf-8'))[0].id
+  ")
+
+  learning_verify "$learn_id" "true" "$project_path"
+  learning_verify "$learn_id" "true" "$project_path"
+
+  local confidence
+  confidence=$(node -p "
+    const e = JSON.parse(require('fs').readFileSync('$project_path','utf-8'));
+    const m = e.find(x => x.id === '$learn_id');
+    m ? m.confidence : -1;
+  ")
+
+  # 2 successes, 0 failures → confidence = 1
+  [ "$confidence" = "1" ]
+}


### PR DESCRIPTION
## Summary

The Ralph Loop previously only learned from **successes**. Failed fix attempts were discarded, bad hints never had their confidence decayed, and when the fix budget was exhausted the feature was marked `failed` and the operator had to restart manually.

This PR addresses all four learning gaps identified in plan `is-there-any-way-atomic-river.md`:

### Changes

**Always-learn on failure** (`scripts/lib/runner.sh`)

- `learning_write` is now called on every failed attempt with a `FAILED[attempt N]:` marker, recording the error signature + attempted fix + resulting error. Future runs can see the pattern was tried and know to try something different.

**Confidence decay for bad hints** (`scripts/lib/runner.sh` + `scripts/lib/learning.sh`)

- `learning_verify "$id" "false"` is now called symmetrically when a retrieved learned-fix hint is applied but tests still fail. Combined with the existing auto-archive logic (`confidence < 0.5 AND hits >= 3`), bad hints gradually get pruned from the store.
- Bug fix: `learning_verify` used bare `return` at the top level of a `node -e` script — a `SyntaxError` silently suppressed by `2>/dev/null || true`, meaning confidence scores were **never updated** in production. Replaced with `process.exit(0)`.

**Cross-attempt context in fix prompt** (`scripts/lib/runner.sh`)

- `phase3-attempts.log` accumulates one stanza per attempt (attempt #, error sig, fix tried, result). From attempt 2 onward the last-3-attempts trail is prepended to `fix_prompt` so Claude knows what approaches already failed.

**Pause-on-exhaustion** (`scripts/lib/runner.sh` + `scripts/lib/display.sh`)

- On fix-budget exhaustion: feature status is set to `paused`, `pause-reason.json` is written, `display_paused_handoff` prints a resume command, and `run_phase3_tests` returns exit code `2`.
- `run_backlog` now distinguishes exit 2 (paused, continue to next feature) from exit 1 (hard failure).
- `display_summary` gains a **Paused** row (8th arg, default 0).

**Bug fix: `_learning_ensure_file`** (`scripts/lib/learning.sh`)

- Changed `[ ! -f ] && echo` to `[ -f ] || echo` — the old pattern returned exit 1 when the file already existed, breaking callers under `set -e`.

### Tests

15 new bats tests across two files, using portable `BATS_TEST_DIRNAME`-relative paths:

- `tests/lib/phase3_pause.bats` — `display_paused_handoff`, `display_summary` Paused row, `pause-reason.json` structure
- `tests/lib/ralph_loop_trail.bats` — trail accumulation format, trim-to-60-lines, `learning_write` failure markers, `learning_verify` confidence decay

All 15 tests pass.

## Test plan

- [ ] Run `bats tests/lib/phase3_pause.bats tests/lib/ralph_loop_trail.bats` — all 15 pass
- [ ] Smoke: run `feature-marker-orchestrate run --autonomy full_auto` with a stub project whose tests always fail; verify feature ends in `paused` state, `pause-reason.json` exists, backlog continues to next feature
- [ ] Check `.claude/feature-state/learned.json` after exhaustion — should contain `FAILED[attempt N]:` entries for each attempt
- [ ] After a second run against a different feature with the same error signature, confirm `learning_read` returns the prior FAILED entry and Claude sees it in the prompt
- [ ] Run `feature-marker-orchestrate --resume-paused <feat_id> --ack` — confirm it picks up from paused state

## Related

- Closes the learning feedback gap identified in the plan for `prd-ralph-loop-learning-ux`
- PR B (terminal UX: phase-aware heartbeat, boxed banners, ANSI color) will follow on a separate branch
