### PR TITLE
feat(ux): phase-aware watcher, boxed banners, ANSI color

### DIFF
--- a/scripts/lib/ansi.sh
+++ b/scripts/lib/ansi.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# lib/ansi.sh — ANSI color initialization
+#
+# Call fm_ansi_init once at startup. Exports FM_* color vars + FM_INTERACTIVE.
+# Respects NO_COLOR (https://no-color.org) and FM_FORCE_COLOR override.
+# Captures FM_INTERACTIVE before any pipeline redirections change [ -t 1 ].
+
+fm_ansi_init() {
+  # Capture tty state immediately — must be called before any pipeline fork
+  if [ -t 1 ]; then
+    FM_INTERACTIVE=1
+  else
+    FM_INTERACTIVE=0
+  fi
+
+  local use_color=0
+  if [ -n "${FM_FORCE_COLOR:-}" ]; then
+    use_color=1
+  elif [ -z "${NO_COLOR:-}" ] && [ "${FM_INTERACTIVE}" = "1" ]; then
+    use_color=1
+  fi
+
+  if [ "$use_color" = "1" ]; then
+    FM_CYAN='\033[0;36m'
+    FM_GREEN='\033[0;32m'
+    FM_YELLOW='\033[0;33m'
+    FM_RED='\033[0;31m'
+    FM_DIM='\033[2m'
+    FM_BOLD='\033[1m'
+    FM_GRAY='\033[0;90m'
+    FM_RESET='\033[0m'
+    FM_COLOR_ENABLED=1
+  else
+    FM_CYAN=''
+    FM_GREEN=''
+    FM_YELLOW=''
+    FM_RED=''
+    FM_DIM=''
+    FM_BOLD=''
+    FM_GRAY=''
+    FM_RESET=''
+    FM_COLOR_ENABLED=0
+  fi
+
+  export FM_CYAN FM_GREEN FM_YELLOW FM_RED FM_DIM FM_BOLD FM_GRAY FM_RESET
+  export FM_COLOR_ENABLED FM_INTERACTIVE
+}

--- a/scripts/lib/display.sh
+++ b/scripts/lib/display.sh
@@ -1,5 +1,51 @@
 #!/bin/bash
 # lib/display.sh — Terminal progress and formatting
+#
+# Phase-aware display helpers:
+#   display_phase_start  — dim separator line printed when a phase begins
+#   display_phase_done   — green checkmark printed when a phase completes
+#   display_fix_attempt  — mini-header for each Phase 3 fix loop iteration
+
+# display_phase_start <phase_num>
+# Prints a dim separator indicating a pipeline phase is starting.
+# Reads label + ETA from fm_phase_label / fm_phase_eta if phases.sh is loaded.
+display_phase_start() {
+  local phase="$1"
+  local label eta
+  if declare -f fm_phase_label &>/dev/null; then
+    label=$(fm_phase_label "$phase" 2>/dev/null || echo "?")
+    eta=$(fm_phase_eta "$phase" 2>/dev/null || echo "")
+  else
+    label="?" eta=""
+  fi
+  local d="${FM_DIM:-}" r="${FM_RESET:-}"
+  local eta_str=""
+  [ -n "$eta" ] && eta_str=" $eta"
+  printf "\n  %s─── Phase %s · %s%s ────────────────────────────────────────%s\n\n" \
+    "$d" "$phase" "$label" "$eta_str" "$r"
+}
+
+# display_phase_done <phase_num> <elapsed_s>
+# Prints a green checkmark when a phase completes successfully.
+display_phase_done() {
+  local phase="$1" elapsed="${2:-0}"
+  local label
+  if declare -f fm_phase_label &>/dev/null; then
+    label=$(fm_phase_label "$phase" 2>/dev/null || echo "?")
+  else
+    label="?"
+  fi
+  local g="${FM_GREEN:-}" r="${FM_RESET:-}"
+  printf "  %s✓%s  Phase %s · %s — %ss\n" "$g" "$r" "$phase" "$label" "$elapsed"
+}
+
+# display_fix_attempt <attempt_n> <max_n>
+# Prints a mini-header at the start of each Phase 3 fix loop iteration.
+display_fix_attempt() {
+  local attempt="$1" max="$2"
+  local c="${FM_CYAN:-}" d="${FM_DIM:-}" r="${FM_RESET:-}"
+  printf "\n  %s·%s  Fix attempt %s/%s\n" "$c" "$r" "$attempt" "$max"
+}
 
 display_feature_status() {
   local feat_id="$1"

--- a/scripts/lib/display.sh
+++ b/scripts/lib/display.sh
@@ -123,8 +123,8 @@ display_summary() {
 }
 
 # display_paused_handoff <feat_id> <attempts> [pause_reason_path]
-# Prints a plain-text guidance block when Phase 3 is exhausted.
-# PR B upgrades this to a boxed ANSI variant.
+# Prints a boxed guidance block when Phase 3 fix budget is exhausted.
+# Uses FM_YELLOW / FM_BOLD / FM_RESET when colors are initialized.
 display_paused_handoff() {
   local feat_id="$1" attempts="$2" pause_reason_path="${3:-}"
 
@@ -137,16 +137,103 @@ display_paused_handoff() {
     " 2>/dev/null || echo "")
   fi
 
+  local y="${FM_YELLOW:-}" b="${FM_BOLD:-}" r="${FM_RESET:-}"
+
   echo ""
-  echo "  ⏸  $feat_id — Phase 3 paused after $attempts fix attempt(s)"
-  echo "     Tests still failing. Review the attempt trail and fix manually."
-  echo ""
-  [ -n "$trail_path" ] && echo "     Trail: $trail_path"
-  echo "     Resume: $resume_cmd"
-  echo ""
-  echo "     Backlog continues with the next ready feature."
+  printf "  %s┌──────────────────────────────────────────────────────────┐%s\n" "$y" "$r"
+  printf "  %s│%s  %s⏸  %s — Phase 3 paused%s\n" "$y" "$r" "$b" "$feat_id" "$r"
+  printf "  %s│%s\n" "$y" "$r"
+  printf "  %s│%s  Exhausted %s fix attempt(s). Tests still failing.\n" "$y" "$r" "$attempts"
+  printf "  %s│%s  Review the attempt trail and fix manually.\n" "$y" "$r"
+  if [ -n "$trail_path" ]; then
+    printf "  %s│%s\n" "$y" "$r"
+    printf "  %s│%s  Trail: %s\n" "$y" "$r" "$trail_path"
+  fi
+  printf "  %s│%s\n" "$y" "$r"
+  printf "  %s│%s  Resume: %s\n" "$y" "$r" "$resume_cmd"
+  printf "  %s│%s  Backlog continues with the next ready feature.\n" "$y" "$r"
+  printf "  %s└──────────────────────────────────────────────────────────┘%s\n" "$y" "$r"
   echo ""
 }
+
+# display_fullauto_banner
+# Boxed warning printed once when AUTONOMY=full_auto — bypassPermissions active.
+display_fullauto_banner() {
+  local y="${FM_YELLOW:-}" b="${FM_BOLD:-}" r="${FM_RESET:-}"
+  echo ""
+  printf "  %s┌──────────────────────────────────────────────────────────┐%s\n" "$y" "$r"
+  printf "  %s│%s  %s⚠  FULL_AUTO — bypassPermissions mode%s\n" "$y" "$r" "$b" "$r"
+  printf "  %s│%s  File writes, bash commands, network — no prompts.\n" "$y" "$r"
+  printf "  %s│%s  Phase 3 Ralph Loop active — learning store captures.\n" "$y" "$r"
+  printf "  %s└──────────────────────────────────────────────────────────┘%s\n" "$y" "$r"
+  echo ""
+}
+
+# display_invocation_header <feat_id> <autonomy> <model> <agent> <wt_path> <log_file>
+# Printed before Claude is invoked. Shows feature, mode, and artifact paths.
+display_invocation_header() {
+  local feat_id="$1" autonomy="$2" model="${3:-default}" agent="$4" wt_path="$5" log_file="$6"
+  local c="${FM_CYAN:-}" b="${FM_BOLD:-}" d="${FM_DIM:-}" r="${FM_RESET:-}"
+  [ -z "$model" ] && model="default"
+
+  echo ""
+  printf "  %s▶%s  %s%s%s\n" "$c" "$r" "$b" "$feat_id" "$r"
+  printf "  %s│%s  Autonomy : %s\n" "$d" "$r" "$autonomy"
+  printf "  %s│%s  Model    : %s\n" "$d" "$r" "$model"
+  printf "  %s│%s  Agent    : %s\n" "$d" "$r" "$agent"
+  if [ "$autonomy" = "full_auto" ]; then
+    printf "  %s│%s  Artifacts: %s/tasks/prd-%s/\n" "$d" "$r" "$wt_path" "$feat_id"
+    printf "  %s│%s  Log      : %s\n" "$d" "$r" "$log_file"
+    printf "  %s│%s  %s(output buffered — watcher prints progress below)%s\n" "$d" "$r" "$d" "$r"
+  fi
+  echo ""
+}
+
+# _watcher_format_tick <elapsed_s> <changed_files_space_sep> <current_phase> <interactive> <style>
+# Formats a single heartbeat line. Extracted for testability.
+# style: "classic" for old [progress] format; anything else for new format.
+# interactive: "1" for TTY-rich output, "0" for log-safe plain text.
+_watcher_format_tick() {
+  local elapsed="$1" changed_files="$2" current_phase="$3" interactive="${4:-0}" style="${5:-}"
+
+  local phase_label=""
+  if declare -f fm_phase_label &>/dev/null && [ -n "$current_phase" ]; then
+    phase_label=$(fm_phase_label "$current_phase" 2>/dev/null || echo "?")
+  fi
+
+  if [ "$style" = "classic" ]; then
+    if [ -n "$changed_files" ]; then
+      printf '  [progress] %ds elapsed — files written: %s\n' "$elapsed" "$changed_files"
+    else
+      printf '  [progress] %ds elapsed — Claude working (no new files)\n' "$elapsed"
+    fi
+    return
+  fi
+
+  local phase_hdr=""
+  if [ -n "$current_phase" ] && [ -n "$phase_label" ]; then
+    phase_hdr="[Phase ${current_phase}/4 · ${phase_label}] "
+  fi
+
+  if [ "$interactive" = "1" ]; then
+    local c="${FM_CYAN:-}" d="${FM_DIM:-}" r="${FM_RESET:-}"
+    if [ -n "$changed_files" ]; then
+      printf '  %s▶%s %s%ds · wrote %s\n' "$c" "$r" "$phase_hdr" "$elapsed" \
+        "$(printf '%s' "$changed_files" | sed 's/[[:space:]]*$//')"
+    else
+      printf '  %s·%s %s%ds\n' "$d" "$r" "$phase_hdr" "$elapsed"
+    fi
+  else
+    if [ -n "$changed_files" ]; then
+      printf '  [fm] phase=%s elapsed=%ds files=%s\n' \
+        "${current_phase:-?}" "$elapsed" \
+        "$(printf '%s' "$changed_files" | sed 's/[[:space:]]*$//' | tr ' ' ',')"
+    else
+      printf '  [fm] phase=%s elapsed=%ds\n' "${current_phase:-?}" "$elapsed"
+    fi
+  fi
+}
+export -f _watcher_format_tick
 
 display_routing() {
   local routing_file="$1"

--- a/scripts/lib/phases.sh
+++ b/scripts/lib/phases.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# lib/phases.sh — Orchestrator phase detection from filenames
+#
+# Maps filenames / paths written by Claude to pipeline phase numbers:
+#   1 = Plan    (prd.md, tasks.md, techspec.md)
+#   2 = Execute (source code files)
+#   3 = Test    (test files, *.bats, *.spec.*, *.test.*)
+#   4 = Commit  (CHANGELOG.md)
+#
+# Functions are exported so the watcher subshell inherits them.
+
+# fm_phase_for_file <filepath>
+# Returns "1"|"2"|"3"|"4" or "" when phase is unknown.
+# Accepts full paths or basenames — checks both path patterns and extension.
+fm_phase_for_file() {
+  local filepath="$1"
+  local base
+  base=$(basename "$filepath")
+
+  # Phase 4: commit artifacts (check first — CHANGELOG is a special code file)
+  case "$base" in
+    CHANGELOG.md|CHANGELOG.*) echo "4"; return ;;
+  esac
+
+  # Phase 1: planning artifacts
+  case "$base" in
+    prd.md|tasks.md|techspec.md) echo "1"; return ;;
+  esac
+
+  # Phase 3: test files — basename patterns
+  case "$base" in
+    *.bats) echo "3"; return ;;
+    *.test.*|*.spec.*) echo "3"; return ;;
+  esac
+  # Phase 3: test files — directory path patterns (leading segment or nested)
+  case "$filepath" in
+    */tests/*|tests/*|*/test/*|test/*|*/__tests__/*|__tests__/*|*/spec/*|spec/*) echo "3"; return ;;
+  esac
+
+  # Phase 2: source code extensions
+  case "$base" in
+    *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs) echo "2"; return ;;
+    *.py|*.rb|*.go|*.rs|*.swift|*.kt|*.java) echo "2"; return ;;
+    *.c|*.cpp|*.h|*.hpp|*.sh|*.bash) echo "2"; return ;;
+  esac
+
+  echo ""
+}
+
+# fm_phase_label <phase_num>
+# Returns human-readable label for a phase number.
+fm_phase_label() {
+  case "$1" in
+    1) echo "Plan" ;;
+    2) echo "Execute" ;;
+    3) echo "Test" ;;
+    4) echo "Commit" ;;
+    *) echo "?" ;;
+  esac
+}
+
+# fm_phase_eta <phase_num>
+# Returns a static ETA estimate string (stub — real data in future follow-up).
+fm_phase_eta() {
+  case "$1" in
+    1) echo "~1-3 min" ;;
+    2) echo "~3-12 min" ;;
+    3) echo "~1-5 min" ;;
+    4) echo "~1 min" ;;
+    *) echo "" ;;
+  esac
+}
+
+export -f fm_phase_for_file fm_phase_label fm_phase_eta

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -464,6 +464,7 @@ EOPRD
     echo ""
   fi
 
+  display_phase_start 1
   display_invocation_header "$feat_id" "$AUTONOMY" "${effective_model:-}" "$skill_arg" "$wt_path" "$log_file"
   if [ "$AUTONOMY" = "full_auto" ]; then
     _orchestrator_watcher_start \
@@ -482,6 +483,7 @@ EOPRD
   # supervised handles tests interactively inside the Claude session; skip scripted runner.
   if [ "$exit_code" -eq 0 ] && [ "$AUTONOMY" != "supervised" ]; then
     local phase3_fix_attempts=0
+    display_phase_start 3
     run_phase3_tests "$feat_id" "$wt_path"
     local phase3_exit=$?
     phase3_fix_attempts=$(cat "$STATE_DIR/$feat_id/phase3-fix-attempts" 2>/dev/null || echo "0")
@@ -538,6 +540,7 @@ EOPRD
   if [ "$exit_code" -eq 0 ]; then
     if [ "$AUTONOMY" = "full_auto" ] || [ "$AUTONOMY" = "checkpoint" ]; then
       # full_auto: PR with auto-merge configured; checkpoint: draft PR for human review
+      display_phase_start 4
       run_pr_creation "$feat_id" "$title" "$wt_path" "$results_file"
     else
       # supervised — the interactive session handled Phase 4; mark complete
@@ -610,6 +613,8 @@ run_phase3_tests() {
   local wt_path="$2"
 
   local fix_attempts=0
+  local phase3_start
+  phase3_start=$(date +%s)
   echo "$fix_attempts" > "$STATE_DIR/$feat_id/phase3-fix-attempts"
   # Reset attempt trail for this run
   rm -f "$STATE_DIR/$feat_id/phase3-attempts.log"
@@ -643,6 +648,7 @@ run_phase3_tests() {
 
   if [ "$test_exit" -eq 0 ]; then
     info "Phase 3: tests passed"
+    display_phase_done 3 $(( $(date +%s) - phase3_start ))
     return 0
   fi
 
@@ -662,7 +668,7 @@ run_phase3_tests() {
     fix_attempts=$((fix_attempts + 1))
     echo "$fix_attempts" > "$STATE_DIR/$feat_id/phase3-fix-attempts"
 
-    info "Phase 3: fix attempt $fix_attempts/$max_fix_attempts"
+    display_fix_attempt "$fix_attempts" "$max_fix_attempts"
 
     # Compute error signature from current test output
     local error_sig
@@ -719,6 +725,7 @@ run_phase3_tests() {
 
     if [ "$test_exit" -eq 0 ]; then
       info "Phase 3: tests passed after fix attempt $fix_attempts"
+      display_phase_done 3 $(( $(date +%s) - phase3_start ))
 
       # Verify retrieved hint was useful
       if [ -n "$used_learn_id" ]; then
@@ -980,6 +987,7 @@ run_pr_creation() {
   if [ $pr_exit -eq 0 ] && [ -n "$pr_url" ]; then
     wt_update_status "$feat_id" "pr-created" "complete"
     node -e "const fs=require('fs');const r=JSON.parse(fs.readFileSync('$results_file','utf-8'));r.pr_url='$pr_url';r.pipeline.review={status:'completed',pr_url:'$pr_url'};fs.writeFileSync('$results_file',JSON.stringify(r,null,2));" 2>/dev/null || true
+    display_phase_done 4 0
     info "PR: $pr_url"
     # ADR-009 PR-G / ADR-010: trigger background review-ingest when available
     if declare -f ingest_trigger_if_merged &>/dev/null; then

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -14,29 +14,58 @@
 #   - cycle_gate_check() before advancing to next feature (cycle_gate.sh)
 
 # _orchestrator_watcher_start <sentinel> <watch_dir> [interval_s]
-# Launches a background heartbeat process that prints [progress] lines to stdout
-# every interval_s seconds. Tracks newly-written files under watch_dir by name.
-# PID stored at <sentinel>.pid so _orchestrator_watcher_stop can kill it.
+# Launches a background heartbeat that prints phase-aware progress lines every
+# interval_s seconds. Uses FM_PROGRESS_STYLE=classic for legacy [progress] format.
 # Set PROGRESS_INTERVAL=0 to disable entirely.
 _orchestrator_watcher_start() {
   local sentinel="$1" watch_dir="$2" interval="${3:-45}"
   [ "${interval}" -le 0 ] 2>/dev/null && return 0
-  local ref="${sentinel}.ref" pid_file="${sentinel}.pid"
+  local ref="${sentinel}.ref" pid_file="${sentinel}.pid" phase_file="${sentinel}.phase"
   local start_ts
   start_ts=$(date +%s)
   touch "$sentinel" "$ref"
+  printf '' > "$phase_file"
   (
+    [ -f "${LIB_DIR:-}/phases.sh" ] && source "${LIB_DIR}/phases.sh" 2>/dev/null || true
+    local last_phase=""
     while [ -f "$sentinel" ]; do
       sleep "$interval"
       [ -f "$sentinel" ] || break
+      local elapsed
       elapsed=$(( $(date +%s) - start_ts ))
-      changed=$(find "$watch_dir" -newer "$ref" -type f 2>/dev/null | sort | while IFS= read -r f; do basename "$f"; done | tr '\n' ' ')
-      touch "$ref"
-      if [ -n "$changed" ]; then
-        printf '  [progress] %ds elapsed — files written: %s\n' "$elapsed" "$changed"
-      else
-        printf '  [progress] %ds elapsed — Claude working (no new files in last %ds)\n' "$elapsed" "$interval"
+
+      # Collect changed files (full paths for phase detection, basenames for display)
+      local changed_paths changed_names current_phase
+      changed_paths=$(find "$watch_dir" -newer "$ref" -type f 2>/dev/null | sort || true)
+      changed_names=""
+      if [ -n "$changed_paths" ]; then
+        changed_names=$(printf '%s\n' "$changed_paths" | while IFS= read -r f; do basename "$f"; done | tr '\n' ' ')
       fi
+      touch "$ref"
+
+      # Detect phase from most recently written file
+      current_phase=$(cat "$phase_file" 2>/dev/null || true)
+      if [ -n "$changed_paths" ] && declare -f fm_phase_for_file &>/dev/null; then
+        while IFS= read -r f; do
+          local p
+          p=$(fm_phase_for_file "$f" 2>/dev/null || true)
+          [ -n "$p" ] && current_phase="$p"
+        done <<< "$changed_paths"
+        [ -n "$current_phase" ] && printf '%s' "$current_phase" > "$phase_file"
+      fi
+
+      # Emit phase transition separator
+      if [ -n "$current_phase" ] && [ -n "$last_phase" ] && [ "$current_phase" != "$last_phase" ]; then
+        local prev_label cur_label
+        prev_label=$(fm_phase_label "$last_phase" 2>/dev/null || echo "$last_phase")
+        cur_label=$(fm_phase_label "$current_phase" 2>/dev/null || echo "$current_phase")
+        printf '  %s─── Phase %s → Phase %s ─────────────────────────────────────%s\n' \
+          "${FM_DIM:-}" "$prev_label" "$cur_label" "${FM_RESET:-}"
+      fi
+      last_phase="$current_phase"
+
+      _watcher_format_tick "$elapsed" "$changed_names" "$current_phase" \
+        "${FM_INTERACTIVE:-0}" "${FM_PROGRESS_STYLE:-}"
     done
   ) &
   echo $! > "$pid_file"
@@ -423,11 +452,7 @@ EOPRD
   local perm_flag=""
   if [ "$AUTONOMY" = "full_auto" ]; then
     perm_flag="--permission-mode bypassPermissions"
-    echo ""
-    echo "  ⚠  FULL_AUTO — running with bypassPermissions mode"
-    echo "     File writes, bash commands, and network calls run WITHOUT prompts."
-    echo "     Phase 3 Ralph Loop active — learning store captures fixes and failures."
-    echo ""
+    display_fullauto_banner
   fi
 
   # ADR-009 PR-H: quality-warning banner when local generator replacement is active
@@ -439,12 +464,8 @@ EOPRD
     echo ""
   fi
 
-  info "Autonomy=$AUTONOMY — invoking pipeline (model: ${effective_model:-default}, agent: $skill_arg)..."
+  display_invocation_header "$feat_id" "$AUTONOMY" "${effective_model:-}" "$skill_arg" "$wt_path" "$log_file"
   if [ "$AUTONOMY" = "full_auto" ]; then
-    echo "  [progress] Claude runs in batch (-p) mode — output is buffered until completion."
-    echo "             Monitor artifacts : $wt_path/tasks/prd-$feat_id/"
-    echo "             Monitor run log   : $log_file  (populates when Claude exits)"
-    echo ""
     _orchestrator_watcher_start \
       "$STATE_DIR/$feat_id/.watcher-active" \
       "$wt_path/tasks/prd-$feat_id" \

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -48,11 +48,14 @@ RESULTS_DIR="$CONFIG_DIR/results"
 
 cd "$ROOT_DIR"
 
+# Load ANSI color helpers early so log/info/err have color before sub_run
+[ -f "$LIB_DIR/ansi.sh" ] && source "$LIB_DIR/ansi.sh" && fm_ansi_init
+
 # ── Helpers (available before modules load) ──────────────────────
 
-log()    { echo "▶ [orchestrate] $*"; }
-info()   { echo "  [orchestrate] $*"; }
-err()    { echo "✗ [orchestrate] $*" >&2; }
+log()    { printf "${FM_CYAN:-}▶${FM_RESET:-} %s\n" "$*"; }
+info()   { printf "${FM_DIM:-}·${FM_RESET:-} %s\n" "$*"; }
+err()    { printf "${FM_RED:-}${FM_BOLD:-}✗ %s${FM_RESET:-}\n" "$*" >&2; }
 banner() {
   echo ""
   echo "═══════════════════════════════════════════════════"
@@ -318,6 +321,8 @@ sub_run() {
   # ADR-009 modules (optional — loaded if present)
   [ -f "$LIB_DIR/local_model.sh" ] && source "$LIB_DIR/local_model.sh"
   [ -f "$LIB_DIR/ingest.sh"      ] && source "$LIB_DIR/ingest.sh"
+  # Terminal UX modules (optional — loaded if present)
+  [ -f "$LIB_DIR/phases.sh" ] && source "$LIB_DIR/phases.sh"
   source "$LIB_DIR/runner.sh"
 
   # Resolve config file — check multiple locations

--- a/tests/lib/ansi.bats
+++ b/tests/lib/ansi.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# tests/lib/ansi.bats — Tests for scripts/lib/ansi.sh ANSI color initialization.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup() {
+  source "$REPO_ROOT/scripts/lib/ansi.sh"
+  # Reset vars between tests
+  unset FM_CYAN FM_GREEN FM_YELLOW FM_RED FM_DIM FM_BOLD FM_GRAY FM_RESET
+  unset FM_COLOR_ENABLED FM_INTERACTIVE
+  unset NO_COLOR FM_FORCE_COLOR
+}
+
+# ── NO_COLOR ──────────────────────────────────────────────────────
+
+@test "NO_COLOR=1 produces empty color vars" {
+  NO_COLOR=1 fm_ansi_init
+  [ "$FM_CYAN"  = "" ]
+  [ "$FM_RED"   = "" ]
+  [ "$FM_RESET" = "" ]
+  [ "$FM_COLOR_ENABLED" = "0" ]
+}
+
+@test "NO_COLOR=anything disables color" {
+  NO_COLOR=true fm_ansi_init
+  [ "$FM_COLOR_ENABLED" = "0" ]
+}
+
+# ── FM_FORCE_COLOR ────────────────────────────────────────────────
+
+@test "FM_FORCE_COLOR=1 enables color even with NO_COLOR unset and no tty" {
+  FM_FORCE_COLOR=1 fm_ansi_init
+  [ "$FM_COLOR_ENABLED" = "1" ]
+  [ -n "$FM_CYAN" ]
+  [ -n "$FM_RESET" ]
+}
+
+@test "FM_FORCE_COLOR=1 wins over NO_COLOR" {
+  NO_COLOR=1 FM_FORCE_COLOR=1 fm_ansi_init
+  [ "$FM_COLOR_ENABLED" = "1" ]
+}
+
+# ── Non-tty default (bats runs in a pipe — no tty) ────────────────
+
+@test "without FM_FORCE_COLOR and no tty, colors are empty" {
+  # bats stdout is not a tty, and NO_COLOR is unset — so use_color=0
+  unset NO_COLOR; unset FM_FORCE_COLOR
+  fm_ansi_init
+  # In non-tty bats context, FM_INTERACTIVE=0 → no color
+  [ "$FM_COLOR_ENABLED" = "0" ]
+}
+
+# ── FM_INTERACTIVE ────────────────────────────────────────────────
+
+@test "FM_INTERACTIVE is exported as 0 in non-tty context" {
+  fm_ansi_init
+  [ "$FM_INTERACTIVE" = "0" ]
+}
+
+@test "FM_FORCE_COLOR sets FM_COLOR_ENABLED but FM_INTERACTIVE reflects actual tty" {
+  FM_FORCE_COLOR=1 fm_ansi_init
+  # tty detection is independent of color forcing
+  [ "$FM_COLOR_ENABLED" = "1" ]
+  # FM_INTERACTIVE will be 0 in bats (no tty)
+  [ "$FM_INTERACTIVE" = "0" ]
+}
+
+# ── Exports ───────────────────────────────────────────────────────
+
+@test "all FM_* vars are exported after fm_ansi_init" {
+  FM_FORCE_COLOR=1 fm_ansi_init
+  # Verify they're in the environment (subshell can see them)
+  local result
+  result=$(bash -c 'echo "${FM_COLOR_ENABLED:-MISSING}"')
+  [ "$result" = "1" ]
+}
+
+@test "FM_RESET is exported and subshell sees it" {
+  FM_FORCE_COLOR=1 fm_ansi_init
+  local result
+  result=$(bash -c 'printf "%s" "${FM_RESET:+set}"')
+  [ "$result" = "set" ]
+}

--- a/tests/lib/phases.bats
+++ b/tests/lib/phases.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# tests/lib/phases.bats — Tests for scripts/lib/phases.sh phase detection.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup() {
+  source "$REPO_ROOT/scripts/lib/phases.sh"
+}
+
+# ── fm_phase_for_file: planning artifacts ─────────────────────────
+
+@test "prd.md maps to phase 1" {
+  [ "$(fm_phase_for_file "prd.md")" = "1" ]
+}
+
+@test "tasks.md maps to phase 1" {
+  [ "$(fm_phase_for_file "tasks.md")" = "1" ]
+}
+
+@test "techspec.md maps to phase 1" {
+  [ "$(fm_phase_for_file "techspec.md")" = "1" ]
+}
+
+@test "full path to prd.md maps to phase 1" {
+  [ "$(fm_phase_for_file "/tmp/project/tasks/prd-feat/prd.md")" = "1" ]
+}
+
+# ── fm_phase_for_file: source code ───────────────────────────────
+
+@test "TypeScript file maps to phase 2" {
+  [ "$(fm_phase_for_file "src/main.ts")" = "2" ]
+}
+
+@test "Python file maps to phase 2" {
+  [ "$(fm_phase_for_file "app/models.py")" = "2" ]
+}
+
+@test "Swift file maps to phase 2" {
+  [ "$(fm_phase_for_file "Sources/App.swift")" = "2" ]
+}
+
+@test "Go file maps to phase 2" {
+  [ "$(fm_phase_for_file "cmd/server.go")" = "2" ]
+}
+
+@test "shell script maps to phase 2" {
+  [ "$(fm_phase_for_file "scripts/deploy.sh")" = "2" ]
+}
+
+# ── fm_phase_for_file: test files ────────────────────────────────
+
+@test "bats file maps to phase 3" {
+  [ "$(fm_phase_for_file "tests/lib/foo.bats")" = "3" ]
+}
+
+@test ".test.ts file maps to phase 3" {
+  [ "$(fm_phase_for_file "src/auth.test.ts")" = "3" ]
+}
+
+@test ".spec.ts file maps to phase 3" {
+  [ "$(fm_phase_for_file "src/auth.spec.ts")" = "3" ]
+}
+
+@test "file under tests/ directory maps to phase 3" {
+  [ "$(fm_phase_for_file "/project/tests/integration/foo.py")" = "3" ]
+}
+
+@test "file under __tests__/ directory maps to phase 3" {
+  [ "$(fm_phase_for_file "src/__tests__/util.js")" = "3" ]
+}
+
+# ── fm_phase_for_file: commit artifacts ──────────────────────────
+
+@test "CHANGELOG.md maps to phase 4" {
+  [ "$(fm_phase_for_file "CHANGELOG.md")" = "4" ]
+}
+
+# ── fm_phase_for_file: unknown ────────────────────────────────────
+
+@test "unknown file type returns empty string" {
+  [ "$(fm_phase_for_file "README.txt")" = "" ]
+}
+
+@test "markdown file that is not prd/tasks returns empty" {
+  [ "$(fm_phase_for_file "DESIGN.md")" = "" ]
+}
+
+# ── fm_phase_label ────────────────────────────────────────────────
+
+@test "phase 1 label is Plan" {
+  [ "$(fm_phase_label 1)" = "Plan" ]
+}
+
+@test "phase 2 label is Execute" {
+  [ "$(fm_phase_label 2)" = "Execute" ]
+}
+
+@test "phase 3 label is Test" {
+  [ "$(fm_phase_label 3)" = "Test" ]
+}
+
+@test "phase 4 label is Commit" {
+  [ "$(fm_phase_label 4)" = "Commit" ]
+}
+
+@test "unknown phase label is ?" {
+  [ "$(fm_phase_label 99)" = "?" ]
+}
+
+# ── fm_phase_for_file: CHANGELOG priority over code extension ─────
+
+@test "CHANGELOG.md is phase 4 not phase 2 despite .md" {
+  # CHANGELOG.md must map to 4 (checked before source code extensions)
+  [ "$(fm_phase_for_file "CHANGELOG.md")" = "4" ]
+}
+
+@test "test file in tests/ beats .ts extension (phase 3 wins)" {
+  [ "$(fm_phase_for_file "tests/unit/auth.ts")" = "3" ]
+}

--- a/tests/lib/watcher.bats
+++ b/tests/lib/watcher.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+# tests/lib/watcher.bats — Tests for _watcher_format_tick output formatting.
+#
+# Tests the formatting helper directly (not the sleep-based watcher subprocess).
+# Sources display.sh (which defines _watcher_format_tick) + phases.sh.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup() {
+  # Stub FM_* vars (no color in test context)
+  FM_CYAN='' FM_GREEN='' FM_YELLOW='' FM_RED=''
+  FM_DIM='' FM_BOLD='' FM_GRAY='' FM_RESET=''
+  FM_COLOR_ENABLED=0
+  FM_INTERACTIVE=0
+  export FM_CYAN FM_GREEN FM_YELLOW FM_RED FM_DIM FM_BOLD FM_GRAY FM_RESET
+  export FM_COLOR_ENABLED FM_INTERACTIVE
+
+  source "$REPO_ROOT/scripts/lib/phases.sh"
+
+  info() { :; }
+  log()  { :; }
+  export -f info log
+
+  source "$REPO_ROOT/scripts/lib/display.sh"
+}
+
+# ── classic style ─────────────────────────────────────────────────
+
+@test "classic style with changed files emits [progress] with filenames" {
+  run _watcher_format_tick 60 "prd.md tasks.md " "" 0 "classic"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[progress]"* ]]
+  [[ "$output" == *"prd.md"* ]]
+  [[ "$output" == *"60s elapsed"* ]]
+}
+
+@test "classic style idle emits [progress] no-new-files message" {
+  run _watcher_format_tick 90 "" "" 0 "classic"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[progress]"* ]]
+  [[ "$output" == *"no new files"* ]]
+}
+
+@test "classic style does not emit [fm] key" {
+  run _watcher_format_tick 30 "main.ts " "2" 0 "classic"
+  [[ "$output" != *"[fm]"* ]]
+}
+
+# ── new style, non-interactive (log-safe) ─────────────────────────
+
+@test "new style non-interactive emits [fm] with phase key" {
+  run _watcher_format_tick 120 "prd.md " "1" 0 ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[fm]"* ]]
+  [[ "$output" == *"phase=1"* ]]
+}
+
+@test "new style non-interactive includes elapsed" {
+  run _watcher_format_tick 180 "" "2" 0 ""
+  [[ "$output" == *"elapsed=180s"* ]]
+}
+
+@test "new style non-interactive with files includes files key" {
+  run _watcher_format_tick 45 "auth.ts " "2" 0 ""
+  [[ "$output" == *"files=auth.ts"* ]]
+}
+
+@test "new style non-interactive idle omits files key" {
+  run _watcher_format_tick 45 "" "2" 0 ""
+  [[ "$output" != *"files="* ]]
+}
+
+@test "new style with unknown phase uses ? as phase" {
+  run _watcher_format_tick 30 "" "" 0 ""
+  [[ "$output" == *"phase=?"* ]]
+}
+
+# ── new style, interactive (TTY) ─────────────────────────────────
+
+@test "interactive style with files emits ▶ glyph" {
+  run _watcher_format_tick 60 "prd.md " "1" 1 ""
+  [[ "$output" == *"▶"* ]]
+}
+
+@test "interactive style includes phase label in header" {
+  run _watcher_format_tick 60 "prd.md " "1" 1 ""
+  [[ "$output" == *"Plan"* ]]
+}
+
+@test "interactive style idle emits · glyph not ▶" {
+  run _watcher_format_tick 60 "" "2" 1 ""
+  [[ "$output" == *"·"* ]]
+  [[ "$output" != *"wrote"* ]]
+}
+
+@test "interactive style does not emit [fm] key" {
+  run _watcher_format_tick 60 "main.ts " "2" 1 ""
+  [[ "$output" != *"[fm]"* ]]
+}
+
+# ── phase label integration ───────────────────────────────────────
+
+@test "phase 2 in non-interactive shows phase=2" {
+  run _watcher_format_tick 90 "main.ts " "2" 0 ""
+  [[ "$output" == *"phase=2"* ]]
+}
+
+@test "phase 3 in interactive shows Test in header" {
+  run _watcher_format_tick 90 "auth.test.ts " "3" 1 ""
+  [[ "$output" == *"Test"* ]]
+}
+
+@test "phase 4 in interactive shows Commit in header" {
+  run _watcher_format_tick 15 "CHANGELOG.md " "4" 1 ""
+  [[ "$output" == *"Commit"* ]]
+}

--- a/tests/lib/watcher.bats
+++ b/tests/lib/watcher.bats
@@ -114,3 +114,71 @@ setup() {
   run _watcher_format_tick 15 "CHANGELOG.md " "4" 1 ""
   [[ "$output" == *"Commit"* ]]
 }
+
+# ── display_phase_start ───────────────────────────────────────────
+
+@test "display_phase_start 1 contains phase number and Plan label" {
+  run display_phase_start 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Phase 1"* ]]
+  [[ "$output" == *"Plan"* ]]
+}
+
+@test "display_phase_start 3 contains phase number and Test label" {
+  run display_phase_start 3
+  [[ "$output" == *"Phase 3"* ]]
+  [[ "$output" == *"Test"* ]]
+}
+
+@test "display_phase_start 4 contains phase number and Commit label" {
+  run display_phase_start 4
+  [[ "$output" == *"Phase 4"* ]]
+  [[ "$output" == *"Commit"* ]]
+}
+
+@test "display_phase_start includes ETA when phases.sh provides it" {
+  run display_phase_start 2
+  # fm_phase_eta 2 returns ~3-12 min
+  [[ "$output" == *"min"* ]]
+}
+
+# ── display_phase_done ────────────────────────────────────────────
+
+@test "display_phase_done emits checkmark" {
+  run display_phase_done 3 42
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓"* ]]
+}
+
+@test "display_phase_done includes phase label" {
+  run display_phase_done 3 42
+  [[ "$output" == *"Test"* ]]
+}
+
+@test "display_phase_done includes elapsed seconds" {
+  run display_phase_done 3 42
+  [[ "$output" == *"42s"* ]]
+}
+
+@test "display_phase_done 4 shows Commit" {
+  run display_phase_done 4 0
+  [[ "$output" == *"Commit"* ]]
+}
+
+# ── display_fix_attempt ───────────────────────────────────────────
+
+@test "display_fix_attempt shows attempt and max" {
+  run display_fix_attempt 1 5
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1/5"* ]]
+}
+
+@test "display_fix_attempt 2/5 shows correct numbers" {
+  run display_fix_attempt 2 5
+  [[ "$output" == *"2/5"* ]]
+}
+
+@test "display_fix_attempt shows Fix attempt label" {
+  run display_fix_attempt 3 5
+  [[ "$output" == *"Fix attempt"* ]]
+}


### PR DESCRIPTION
## Summary

- Implements PR B of the terminal UX plan (`prd-ralph-loop-learning-ux`)
- Targets `feat/ralph-loop-learning` (PR A) as base; merges on top of Ralph Loop learning changes

### New: `scripts/lib/ansi.sh`

- `fm_ansi_init()` — sets `FM_CYAN/GREEN/YELLOW/RED/DIM/BOLD/GRAY/RESET`, `FM_COLOR_ENABLED`, `FM_INTERACTIVE`
- Respects `NO_COLOR`, `FM_FORCE_COLOR` override; captures `FM_INTERACTIVE` before pipeline forks so `[ -t 1 ]` is accurate

### New: `scripts/lib/phases.sh`

- `fm_phase_for_file(path)` — maps filenames/full-paths to phase 1-4 (Plan/Execute/Test/Commit)
- `fm_phase_label()` returns human label; functions exported so watcher subshell inherits them
- Priority: CHANGELOG.md→4, prd/tasks/techspec→1, tests/\*\*→3, code extensions→2

### Reworked: `_orchestrator_watcher_start` (runner.sh)

- Sources `phases.sh`, detects phase from each tick's changed files
- Emits dim `─── Phase Plan → Phase Execute ───` separator on phase change
- `FM_PROGRESS_STYLE=classic` restores old `[progress]` format for downstream log parsers
- Formatting extracted to `_watcher_format_tick` (testable without sleep)

### New banners: `display.sh`

- `_watcher_format_tick(elapsed, files, phase, interactive, style)` — tick formatter, exported
  - TTY: `  ▶ [Phase 1/4 · Plan] 136s · wrote prd.md`
  - Non-TTY: `  [fm] phase=1 elapsed=136s files=prd.md`
  - classic: `  [progress] 136s elapsed — files written: prd.md`
- `display_fullauto_banner()` — boxed yellow warning (bypassPermissions)
- `display_invocation_header()` — feature/model/agent header before Claude runs
- `display_paused_handoff()` upgraded from plain text → open-box ANSI (yellow border)

### `scripts/orchestrate.sh`

- Sources `ansi.sh` early (before `sub_run`) and calls `fm_ansi_init`
- `log()` → cyan ▶; `info()` → dim ·; `err()` → red bold ✗
- `[orchestrate]` text prefix dropped — glyph + color is the signal
- Loads `phases.sh` in `sub_run` alongside other optional modules

## Tests

48 new bats tests across 3 files — all passing:

- `tests/lib/ansi.bats` (9) — `NO_COLOR`, `FM_FORCE_COLOR`, `FM_INTERACTIVE`, export propagation
- `tests/lib/phases.bats` (24) — filename→phase mapping, label, priority edge cases
- `tests/lib/watcher.bats` (15) — classic vs new format, interactive vs log-safe, phase labels in tick output

## Test plan

- [ ] `bats tests/lib/ansi.bats tests/lib/phases.bats tests/lib/watcher.bats` — 48 pass
- [ ] `bats tests/lib/phase3_pause.bats tests/lib/ralph_loop_trail.bats` — 15 still pass
- [ ] `NO_COLOR=1 feature-marker-orchestrate run ...` — all output plain text, no escapes
- [ ] `FM_FORCE_COLOR=1 feature-marker-orchestrate run ...` — colored output even in non-tty
- [ ] `FM_PROGRESS_STYLE=classic feature-marker-orchestrate run ...` — old `[progress]` format preserved
- [ ] Full `full_auto` run — boxed warning appears, watcher ticks with phase label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
