### PR TITLE
feat(security): ADR-011 PR-E — spec reference validation and build verification

### DIFF
--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -457,6 +457,26 @@ EOPRD
 
   _orchestrator_watcher_stop "$STATE_DIR/$feat_id/.watcher-active"
 
+  # ADR-011 PR-E: validate spec references against project inventory (pre-Phase 3)
+  if [ "$exit_code" -eq 0 ] && [ -f "${LIB_DIR}/../validate_spec_references.sh" ]; then
+    bash "${LIB_DIR}/../validate_spec_references.sh" "$wt_path" "$task_dir" 2>&1 || {
+      warn "validate_spec_references: unresolved references — continuing (advisory)"
+    }
+  fi
+
+  # ADR-011 PR-E: verify build before Phase 3 tests
+  if [ "$exit_code" -eq 0 ] && [ -f "${LIB_DIR}/../verify_build.sh" ]; then
+    local build_exit=0
+    bash "${LIB_DIR}/../verify_build.sh" "$wt_path" 2>&1 || build_exit=$?
+    if [ "$build_exit" -eq 1 ]; then
+      warn "verify_build: build broken — pausing $feat_id"
+      wt_update_status "$feat_id" "paused" "build-broken"
+      _runner_record_pause "$feat_id" "human" "build-broken"
+      return 0
+    fi
+    # exit 2 = soft skip (no build cmd) — continue normally
+  fi
+
   # ── ADR-008 PR-A: Phase 3 scripted tests ────────────────────────
   # supervised handles tests interactively inside the Claude session; skip scripted runner.
   if [ "$exit_code" -eq 0 ] && [ "$AUTONOMY" != "supervised" ]; then
@@ -690,6 +710,17 @@ run_phase3_tests() {
     else
       info "Phase 3: Claude CLI not found — cannot attempt fix"
       return 1
+    fi
+
+    # ADR-011 PR-E: verify build compiles after each fix attempt
+    if [ -f "${LIB_DIR}/../verify_build.sh" ]; then
+      local _build_exit=0
+      bash "${LIB_DIR}/../verify_build.sh" "$wt_path" 2>/dev/null || _build_exit=$?
+      if [ "$_build_exit" -eq 1 ]; then
+        info "Phase 3: build broken after fix attempt $fix_attempts — continuing to next attempt"
+        test_exit=1
+        continue
+      fi
     fi
 
     # Re-run tests after fix attempt

--- a/scripts/validate_spec_references.sh
+++ b/scripts/validate_spec_references.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# scripts/validate_spec_references.sh — Spec reference validator (ADR-011 PR-E)
+#
+# Parses generated PRD/techspec/tasks.md files and cross-checks file path
+# references against the worktree inventory (inventory.json).
+# "Declared-new" artifacts listed in tasks.md as to-be-created are allowed.
+#
+# Usage:
+#   bash scripts/validate_spec_references.sh <wt_path> <task_dir>
+#
+# Exit codes:
+#   0 — all file-path references are either existing or declared-new
+#   1 — unresolved file paths that don't exist and aren't declared in tasks
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+_validate_references() {
+  local wt_path="$1"
+  local task_dir="$2"
+
+  local inv="$wt_path/.orchestrator/inventory.json"
+  if [ ! -f "$inv" ]; then
+    echo "validate_spec_references: no inventory.json — skipping" >&2
+    return 0
+  fi
+
+  local prd="$task_dir/prd.md"
+  local techspec="$task_dir/techspec.md"
+  local tasks="$task_dir/tasks.md"
+
+  # At minimum prd.md must exist for there to be anything to validate
+  if [ ! -f "$prd" ] && [ ! -f "$techspec" ] && [ ! -f "$tasks" ]; then
+    echo "validate_spec_references: no spec docs found — skipping"
+    return 0
+  fi
+
+  # Write doc list to a temp file so Python gets stable argv
+  local tmpfile
+  tmpfile=$(mktemp)
+  for doc in "$prd" "$techspec" "$tasks"; do
+    [ -f "$doc" ] && echo "$doc" >> "$tmpfile" || true
+  done
+
+  local result
+  result=$(python3 - "$inv" "$tasks" "$tmpfile" <<'PYEOF'
+import sys, json, os, re
+
+inv_path = sys.argv[1]
+tasks_path = sys.argv[2]
+doc_list_file = sys.argv[3]
+
+inv = json.load(open(inv_path))
+existing_files = set(inv.get('files', []))
+existing_basenames = {os.path.basename(f) for f in existing_files}
+
+# Collect declared-new: backtick tokens in task checklist lines
+declared_new = set()
+if os.path.isfile(tasks_path):
+    for line in open(tasks_path):
+        if re.match(r'\s*-\s*\[[ x]\]', line, re.I):
+            for m in re.finditer(r'`([^`\n]+)`', line):
+                declared_new.add(m.group(1).strip())
+            # bare filenames after create/add/write/implement
+            for m in re.finditer(
+                r'\b(?:create|add|write|implement|define)\s+([A-Za-z0-9_./]+\.[A-Za-z]+)',
+                line, re.I
+            ):
+                declared_new.add(m.group(1))
+
+# Collect file-path-like references from all spec docs
+FILE_EXTS = ('.swift', '.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs',
+             '.md', '.json', '.yaml', '.yml', '.sh', '.kt', '.java', '.rb')
+
+refs = set()
+for doc_path in open(doc_list_file).read().splitlines():
+    if not os.path.isfile(doc_path):
+        continue
+    text = open(doc_path).read()
+    for m in re.finditer(r'`([^`\n]+)`', text):
+        tok = m.group(1).strip()
+        if ('/' in tok or tok.endswith(FILE_EXTS)) and len(tok) > 3:
+            refs.add(tok)
+
+warnings = []
+for ref in sorted(refs):
+    if ref in declared_new:
+        continue
+    basename = os.path.basename(ref)
+    if ref in existing_files or basename in existing_basenames:
+        continue
+    # New files (not yet created) that appear in specs but not in inventory
+    # are only warned if they have a directory path — bare filenames are likely new
+    if '/' in ref:
+        warnings.append(f"UNRESOLVED-FILE: {ref}")
+
+for w in warnings[:10]:
+    print(w)
+if warnings:
+    sys.exit(1)
+PYEOF
+)
+  local py_exit=$?
+  rm -f "$tmpfile"
+
+  if [ "$py_exit" -ne 0 ] && [ -n "$result" ]; then
+    echo "validate_spec_references: unresolved file references in spec for $(basename "$task_dir"):" >&2
+    echo "$result" >&2
+    return 1
+  fi
+
+  echo "validate_spec_references: spec references OK for $(basename "$task_dir")"
+  return 0
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+case "${1:-help}" in
+  verify)
+    shift
+    _validate_references "$@"
+    ;;
+  *)
+    if [ $# -ge 2 ] && [ "$1" != "help" ]; then
+      _validate_references "$@"
+    else
+      echo "Usage: validate_spec_references.sh <wt_path> <task_dir>"
+      exit 1
+    fi
+    ;;
+esac

--- a/scripts/verify_build.sh
+++ b/scripts/verify_build.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# scripts/verify_build.sh — Build verification gate (ADR-011 PR-E)
+#
+# Runs the project build command (from stack_profile / platform-context.json)
+# inside the feature worktree. Non-zero exit pauses the feature run with
+# reason "build-broken" so a human can review before PR creation.
+#
+# Usage:
+#   bash scripts/verify_build.sh <wt_path>
+#
+# Exit codes:
+#   0 — build succeeded
+#   1 — build failed (or no build command configured)
+#   2 — build command not configured / unknown stack (soft skip)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+_read_build_cmd() {
+  local wt_path="$1"
+  local ctx="$wt_path/.orchestrator/platform-context.json"
+  [ -f "$ctx" ] || return 0
+
+  python3 - "$ctx" <<'PYEOF'
+import sys, json
+
+ctx = json.load(open(sys.argv[1]))
+
+# platform-context.json may use different key names depending on who wrote it
+cmd = (ctx.get('build_command') or
+       ctx.get('PROJECT_BUILD_CMD') or
+       ctx.get('buildCommand') or
+       '')
+print(cmd)
+PYEOF
+}
+
+_verify_build() {
+  local wt_path="$1"
+
+  # Resolve absolute wt_path
+  if ! wt_abs=$(cd "$wt_path" 2>/dev/null && pwd); then
+    echo "verify_build: worktree $wt_path not found — skipping" >&2
+    return 2
+  fi
+
+  local build_cmd
+  build_cmd=$(_read_build_cmd "$wt_abs") || build_cmd=""
+
+  if [ -z "$build_cmd" ]; then
+    echo "verify_build: no build command configured — skipping build check" >&2
+    return 2
+  fi
+
+  echo "verify_build: running '$build_cmd' in $wt_abs..."
+  local log_dir="$wt_abs/.orchestrator"
+  mkdir -p "$log_dir"
+  local log_file="$log_dir/verify-build.log"
+
+  local build_exit=0
+  (
+    cd "$wt_abs"
+    eval "$build_cmd"
+  ) > "$log_file" 2>&1 || build_exit=$?
+
+  if [ "$build_exit" -ne 0 ]; then
+    echo "verify_build: FAIL — build exited $build_exit" >&2
+    echo "verify_build: last 20 lines of build log:" >&2
+    tail -20 "$log_file" >&2
+    return 1
+  fi
+
+  echo "verify_build: build succeeded"
+  return 0
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+case "${1:-help}" in
+  check)
+    shift
+    _verify_build "$@"
+    ;;
+  *)
+    if [ $# -ge 1 ] && [ "$1" != "help" ]; then
+      _verify_build "$@"
+    else
+      echo "Usage: verify_build.sh <wt_path>"
+      exit 1
+    fi
+    ;;
+esac

--- a/tests/lib/validate_spec_references.bats
+++ b/tests/lib/validate_spec_references.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# tests/lib/validate_spec_references.bats — Unit tests for validate_spec_references.sh (ADR-011 PR-E)
+bats_require_minimum_version 1.5.0
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+VALIDATE_REFS="$REPO_ROOT/scripts/validate_spec_references.sh"
+SWIFT_FIXTURE="$REPO_ROOT/tests/fixtures/swift-sample"
+
+setup() {
+  TMPDIR_WT="$(mktemp -d)"
+  TASK_DIR="$TMPDIR_WT/tasks/prd-test"
+  mkdir -p "$TASK_DIR"
+  mkdir -p "$TMPDIR_WT/.orchestrator"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_WT"
+}
+
+_write_inventory() {
+  python3 -c "
+import json, sys
+data = {
+    'stack': 'ios',
+    'files': ['Sources/App/main.swift', 'Sources/SampleLib/SampleApp.swift', 'Tests/AppTests/AppTests.swift', 'Package.swift'],
+    'manifest': {'targets': ['App', 'SampleLib', 'AppTests']},
+    'symbols': ['SampleApp', 'Greeter', 'Runnable', 'AppRunner']
+}
+json.dump(data, open('$TMPDIR_WT/.orchestrator/inventory.json', 'w'), indent=2)
+"
+}
+
+# ── no inventory ──────────────────────────────────────────────────────────────
+
+@test "exits 0 (skip) when no inventory.json exists" {
+  run bash "$VALIDATE_REFS" "$TMPDIR_WT" "$TASK_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "exits 0 (skip) when no spec docs exist" {
+  _write_inventory
+  run bash "$VALIDATE_REFS" "$TMPDIR_WT" "$TASK_DIR"
+  [ "$status" -eq 0 ]
+}
+
+# ── clean references ──────────────────────────────────────────────────────────
+
+@test "exits 0 when prd.md references existing files only" {
+  _write_inventory
+  cat > "$TASK_DIR/prd.md" <<'EOF'
+# My Feature
+
+Modify `Sources/SampleLib/SampleApp.swift` to add login support.
+Also update `Package.swift`.
+EOF
+  run bash "$VALIDATE_REFS" "$TMPDIR_WT" "$TASK_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "exits 0 when techspec.md references existing symbol" {
+  _write_inventory
+  cat > "$TASK_DIR/techspec.md" <<'EOF'
+# Tech Spec
+
+Extend the `SampleApp` struct with a new method.
+Use `Greeter` for display.
+EOF
+  run bash "$VALIDATE_REFS" "$TMPDIR_WT" "$TASK_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "exits 0 when no file-path references present" {
+  _write_inventory
+  cat > "$TASK_DIR/prd.md" <<'EOF'
+# Feature
+
+Add a new login screen with email/password fields.
+Validate user credentials before allowing access.
+EOF
+  run bash "$VALIDATE_REFS" "$TMPDIR_WT" "$TASK_DIR"
+  [ "$status" -eq 0 ]
+}
+
+# ── declared-new passes ───────────────────────────────────────────────────────
+
+@test "exits 0 when spec references a file declared new in tasks.md" {
+  _write_inventory
+  cat > "$TASK_DIR/prd.md" <<'EOF'
+# Feature
+
+Add `Sources/App/LoginViewModel.swift` for login logic.
+EOF
+  cat > "$TASK_DIR/tasks.md" <<'EOF'
+# Tasks
+
+- [ ] Create `Sources/App/LoginViewModel.swift`
+- [ ] Add unit tests
+EOF
+  run bash "$VALIDATE_REFS" "$TMPDIR_WT" "$TASK_DIR"
+  [ "$status" -eq 0 ]
+}
+
+# ── unresolved references ─────────────────────────────────────────────────────
+
+@test "exits 1 when prd.md references a nonexistent path not declared in tasks" {
+  _write_inventory
+  cat > "$TASK_DIR/prd.md" <<'EOF'
+# Feature
+
+Modify `Sources/Auth/AuthManager.swift` to add OAuth support.
+This file contains the core auth logic.
+EOF
+  run bash "$VALIDATE_REFS" "$TMPDIR_WT" "$TASK_DIR"
+  [ "$status" -eq 1 ]
+}
+
+@test "unresolved reference appears in stderr output" {
+  _write_inventory
+  cat > "$TASK_DIR/prd.md" <<'EOF'
+# Feature
+
+Extend `Sources/Auth/AuthManager.swift` with new methods.
+EOF
+  run bash "$VALIDATE_REFS" "$TMPDIR_WT" "$TASK_DIR" 2>&1
+  [[ "$output" =~ "UNRESOLVED-FILE" ]] || [[ "$output" =~ "AuthManager" ]] || [ "$status" -eq 1 ]
+}
+
+# ── basename matching ─────────────────────────────────────────────────────────
+
+@test "exits 0 when spec references file by basename matching existing" {
+  _write_inventory
+  cat > "$TASK_DIR/prd.md" <<'EOF'
+# Feature
+
+Update `SampleApp.swift` to support the new login flow.
+EOF
+  run bash "$VALIDATE_REFS" "$TMPDIR_WT" "$TASK_DIR"
+  [ "$status" -eq 0 ]
+}

--- a/tests/lib/verify_build.bats
+++ b/tests/lib/verify_build.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# tests/lib/verify_build.bats — Unit tests for verify_build.sh (ADR-011 PR-E)
+bats_require_minimum_version 1.5.0
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+VERIFY_BUILD="$REPO_ROOT/scripts/verify_build.sh"
+STUBS="$REPO_ROOT/tests/stubs"
+
+setup() {
+  TMPDIR_WT="$(mktemp -d)"
+  mkdir -p "$TMPDIR_WT/.orchestrator"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_WT"
+}
+
+# ── no platform-context.json ──────────────────────────────────────────────────
+
+@test "exits 2 (soft skip) when no platform-context.json exists" {
+  run bash "$VERIFY_BUILD" "$TMPDIR_WT"
+  [ "$status" -eq 2 ]
+}
+
+@test "exits 2 when platform-context.json has no build_command" {
+  echo '{"stack":"unknown"}' > "$TMPDIR_WT/.orchestrator/platform-context.json"
+  run bash "$VERIFY_BUILD" "$TMPDIR_WT"
+  [ "$status" -eq 2 ]
+}
+
+@test "exits 0 (skip) for nonexistent worktree path" {
+  run bash "$VERIFY_BUILD" "/tmp/no-such-dir-$$"
+  [ "$status" -eq 2 ]
+}
+
+# ── successful build ──────────────────────────────────────────────────────────
+
+@test "exits 0 when build command succeeds" {
+  echo "{\"build_command\":\"$STUBS/swift-build-ok.sh\"}" \
+    > "$TMPDIR_WT/.orchestrator/platform-context.json"
+  run bash "$VERIFY_BUILD" "$TMPDIR_WT"
+  [ "$status" -eq 0 ]
+}
+
+@test "prints build succeeded on success" {
+  echo "{\"build_command\":\"$STUBS/swift-build-ok.sh\"}" \
+    > "$TMPDIR_WT/.orchestrator/platform-context.json"
+  run bash "$VERIFY_BUILD" "$TMPDIR_WT"
+  [[ "$output" =~ "build succeeded" ]]
+}
+
+@test "creates verify-build.log on successful build" {
+  echo "{\"build_command\":\"$STUBS/swift-build-ok.sh\"}" \
+    > "$TMPDIR_WT/.orchestrator/platform-context.json"
+  bash "$VERIFY_BUILD" "$TMPDIR_WT"
+  [ -f "$TMPDIR_WT/.orchestrator/verify-build.log" ]
+}
+
+# ── failed build ──────────────────────────────────────────────────────────────
+
+@test "exits 1 when build command fails" {
+  echo "{\"build_command\":\"$STUBS/swift-build-fail.sh\"}" \
+    > "$TMPDIR_WT/.orchestrator/platform-context.json"
+  run bash "$VERIFY_BUILD" "$TMPDIR_WT"
+  [ "$status" -eq 1 ]
+}
+
+@test "prints FAIL on build failure" {
+  echo "{\"build_command\":\"$STUBS/swift-build-fail.sh\"}" \
+    > "$TMPDIR_WT/.orchestrator/platform-context.json"
+  run bash "$VERIFY_BUILD" "$TMPDIR_WT"
+  [[ "$output" =~ "FAIL" ]]
+}
+
+@test "creates verify-build.log on failed build" {
+  echo "{\"build_command\":\"$STUBS/swift-build-fail.sh\"}" \
+    > "$TMPDIR_WT/.orchestrator/platform-context.json"
+  bash "$VERIFY_BUILD" "$TMPDIR_WT" 2>/dev/null || true
+  [ -f "$TMPDIR_WT/.orchestrator/verify-build.log" ]
+}
+
+@test "verify-build.log contains build output on failure" {
+  echo "{\"build_command\":\"$STUBS/swift-build-fail.sh\"}" \
+    > "$TMPDIR_WT/.orchestrator/platform-context.json"
+  bash "$VERIFY_BUILD" "$TMPDIR_WT" 2>/dev/null || true
+  run grep -q "error" "$TMPDIR_WT/.orchestrator/verify-build.log"
+  [ "$status" -eq 0 ]
+}
+
+# ── alternate key names ───────────────────────────────────────────────────────
+
+@test "reads PROJECT_BUILD_CMD key from platform-context.json" {
+  echo "{\"PROJECT_BUILD_CMD\":\"$STUBS/swift-build-ok.sh\"}" \
+    > "$TMPDIR_WT/.orchestrator/platform-context.json"
+  run bash "$VERIFY_BUILD" "$TMPDIR_WT"
+  [ "$status" -eq 0 ]
+}

--- a/tests/stubs/swift-build-fail.sh
+++ b/tests/stubs/swift-build-fail.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: simulates a failing swift build (exit 1)
+echo "error: cannot find type 'NonExistentType' in scope" >&2
+exit 1

--- a/tests/stubs/swift-build-ok.sh
+++ b/tests/stubs/swift-build-ok.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: simulates a successful swift build (exit 0)
+echo "Build complete!"
+exit 0


### PR DESCRIPTION
## Summary

- `scripts/validate_spec_references.sh`: parses backtick code spans from prd.md, techspec.md, tasks.md; cross-checks path references (containing `/` or having source file extensions) against `inventory.json`. Tokens listed in tasks.md checklist items as "declared-new" are allowed. Basename matching lets specs reference files without full paths. Advisory-only (warns but doesn't block) — unresolved symbols are not flagged (only path references with `/`).
- `scripts/verify_build.sh`: reads `build_command` (or `PROJECT_BUILD_CMD`) from `.orchestrator/platform-context.json`; runs the build inside the worktree; exit 1 = build broken (pauses the feature with reason `build-broken`); exit 2 = soft skip (no build cmd configured). Wires into runner.sh at two sites: pre-Phase 3 tests and inside the Ralph fix loop (skips to next attempt on broken build).
- `tests/stubs/swift-build-ok.sh` / `swift-build-fail.sh`: lightweight build stubs used by bats tests (avoids running actual Swift/xcodebuild in CI)
- `runner.sh`: spec validation call pre-Phase 3 (advisory); build verification pre-Phase 3 and post-each-fix-attempt
- 20 bats tests (all green): build success/failure, log generation, no-inventory skip, declared-new bypass, basename matching, unresolved path detection

## Test plan

- [ ] `bats tests/lib/verify_build.bats` — 11 tests pass
- [ ] `bats tests/lib/validate_spec_references.bats` — 9 tests pass
- [ ] Smoke: write platform-context.json with valid build cmd, run verify_build.sh
- [ ] Verify validate_spec_references.sh exits 0 with no inventory (graceful skip)
- [ ] Verify validate_spec_references.sh exits 1 for path ref not in inventory

Generated with Claude Code
