### PR TITLE
feat(ux): orchestrator color output + live-phase heartbeat

### DIFF
--- a/scripts/lib/display.sh
+++ b/scripts/lib/display.sh
@@ -45,9 +45,12 @@ display_backlog() {
 display_backlog_table() {
   local active_feat="${1:-}"
   [ ! -d "$STATE_DIR" ] && return
+  local _g="${C_GREEN:-}" _r="${C_RED:-}" _y="${C_YELLOW:-}" \
+        _cy="${C_CYAN:-}" _d="${C_DIM:-}" _bo="${C_BOLD:-}" _nc="${C_NC:-}"
   node -e "
     const fs = require('fs'), path = require('path');
     const sd = '$STATE_DIR', active = '$active_feat';
+    const G='$_g', R='$_r', Y='$_y', CY='$_cy', D='$_d', BO='$_bo', NC='$_nc';
     let dirs;
     try { dirs = fs.readdirSync(sd).filter(d => fs.existsSync(path.join(sd,d,'status.json'))); }
     catch(e) { process.exit(0); }
@@ -61,28 +64,30 @@ display_backlog_table() {
     const doneN = features.filter(f=>f.status==='done'||f.status==='pr-created').length;
     const totalTok = features.reduce((s,f)=>s+f.tokens,0);
     const fmtTok = n => n>=1000 ? Math.round(n/1000)+'k' : (n||'—');
+    // icon() returns a single colored glyph (1 visible char + ANSI codes).
+    // Status cell = icon(1) + space(1) + label(≤10 padded) = 12 visible chars.
     const icon = f => {
-      if (f.id===active||f.status==='in-progress') return '→';
-      if (f.status==='done'||f.status==='pr-created') return '✓';
-      if (f.status==='failed') return '✗';
-      if (f.status==='paused') return '⏸';
-      return '·';
+      if (f.id===active||f.status==='in-progress') return CY+'→'+NC;
+      if (f.status==='done'||f.status==='pr-created') return G+'✓'+NC;
+      if (f.status==='failed') return R+'✗'+NC;
+      if (f.status==='paused') return Y+'⏸'+NC;
+      return D+'·'+NC;
     };
-    const hdr = '  BACKLOG  ['+doneN+'/'+features.length+' done]'+(totalTok?' — ~'+fmtTok(totalTok)+' tokens':'');
+    const hdrText = '  BACKLOG  ['+doneN+'/'+features.length+' done]'+(totalTok?' — ~'+fmtTok(totalTok)+' tokens':'');
     const W = 64;
     const pad = (s,n) => String(s).substring(0,n).padEnd(n);
     console.log('');
     console.log('  ┌'+'─'.repeat(W)+'┐');
-    console.log('  │  '+hdr.padEnd(W-2)+'│');
+    console.log('  │  '+BO+CY+hdrText+NC+' '.repeat(Math.max(0,W-2-hdrText.length))+'│');
     console.log('  ├'+'─'.repeat(16)+'┬'+'─'.repeat(14)+'┬'+'─'.repeat(14)+'┬'+'─'.repeat(18)+'┤');
     console.log('  │  '+pad('Feature',14)+'│  '+pad('Status',12)+'│  '+pad('Phase',12)+'│  '+pad('Tokens',14)+'│');
     console.log('  ├'+'─'.repeat(16)+'┼'+'─'.repeat(14)+'┼'+'─'.repeat(14)+'┼'+'─'.repeat(18)+'┤');
     for (const f of features) {
       const ico = icon(f);
-      const sl = (ico+' '+(f.status==='pr-created'?'pr-created':f.status)).substring(0,12).padEnd(12);
+      const statusLabel = (f.status==='pr-created'?'pr-created':f.status).substring(0,10).padEnd(10);
       const pl = (f.phase).substring(0,12).padEnd(12);
       const tl = String(fmtTok(f.tokens)).padStart(14);
-      console.log('  │  '+pad(f.id,14)+'│  '+sl+'│  '+pl+'│  '+tl+'  │');
+      console.log('  │  '+pad(f.id,14)+'│  '+ico+' '+statusLabel+'│  '+pl+'│  '+tl+'  │');
     }
     console.log('  └'+'─'.repeat(16)+'┴'+'─'.repeat(14)+'┴'+'─'.repeat(14)+'┴'+'─'.repeat(18)+'┘');
   " 2>/dev/null || true
@@ -138,11 +143,11 @@ display_paused_handoff() {
   fi
 
   echo ""
-  echo "  ⏸  $feat_id — Phase 3 paused after $attempts fix attempt(s)"
+  printf "  ${C_YELLOW:-}⏸${C_NC:-}  %s — Phase 3 paused after %s fix attempt(s)\n" "$feat_id" "$attempts"
   echo "     Tests still failing. Review the attempt trail and fix manually."
   echo ""
   [ -n "$trail_path" ] && echo "     Trail: $trail_path"
-  echo "     Resume: $resume_cmd"
+  printf "     Resume: ${C_CYAN:-}%s${C_NC:-}\n" "$resume_cmd"
   echo ""
   echo "     Backlog continues with the next ready feature."
   echo ""
@@ -181,20 +186,65 @@ display_next_steps() {
 
   echo ""
   if [ "$exit_code" -ne 0 ]; then
-    printf "  ⚠  %s exited with errors (code %s) — review log before continuing.\n" "$feat_id" "$exit_code"
+    printf "  ${C_YELLOW:-}⚠${C_NC:-}  %s exited with errors (code %s) — review log before continuing.\n" "$feat_id" "$exit_code"
   fi
   printf "  ┌%s┐\n" "$(printf '─%.0s' $(seq 1 $W))"
   if [ -n "$next_feat" ]; then
-    printf "  │  %-*s│\n" "$inner" "$feat_id → done.  Next: $next_feat"
+    printf "  │  ${C_GREEN:-}%-*s${C_NC:-}│\n" "$inner" "$feat_id → done.  Next: $next_feat"
     printf "  │  %-*s│\n" "$inner" ""
     printf "  │  %-*s│\n" "$inner" "Continue with the same command:"
     printf "  │  %-*s│\n" "$inner" ""
-    printf "  │    %-*s│\n" "$((inner - 2))" "$cmd"
+    printf "  │    ${C_CYAN:-}%-*s${C_NC:-}│\n" "$((inner - 2))" "$cmd"
   else
-    printf "  │  %-*s│\n" "$inner" "All features complete."
+    printf "  │  ${C_GREEN:-}%-*s${C_NC:-}│\n" "$inner" "All features complete."
     printf "  │  %-*s│\n" "$inner" ""
     printf "  │  %-*s│\n" "$inner" "Run: feature-marker-orchestrate status"
   fi
   printf "  └%s┘\n" "$(printf '─%.0s' $(seq 1 $W))"
   echo ""
+}
+
+# display_live_phase <feat_id> <start_epoch>
+# Reads $STATE_DIR/$feat_id/status.json and cost.json to emit a one-line
+# live status during a Claude run. Gracefully omits missing segments.
+display_live_phase() {
+  local feat_id="$1" start_epoch="${2:-0}"
+  local status_file="$STATE_DIR/$feat_id/status.json"
+  local cost_file="$STATE_DIR/$feat_id/cost.json"
+
+  local phase="" task_seg="" tokens="?" elapsed=""
+
+  if [ -f "$status_file" ]; then
+    phase=$(node -p "
+      try {
+        const s = JSON.parse(require('fs').readFileSync('$status_file','utf-8'));
+        s.phase || '?';
+      } catch(e) { '?'; }
+    " 2>/dev/null || echo "?")
+    task_seg=$(node -p "
+      try {
+        const s = JSON.parse(require('fs').readFileSync('$status_file','utf-8'));
+        (s.task_index && s.total_tasks) ? ' · task ' + s.task_index + '/' + s.total_tasks : '';
+      } catch(e) { ''; }
+    " 2>/dev/null || echo "")
+  fi
+
+  if [ -f "$cost_file" ]; then
+    tokens=$(node -p "
+      try {
+        const t = JSON.parse(require('fs').readFileSync('$cost_file','utf-8')).cumulative_tokens || 0;
+        '~' + (t >= 1000 ? Math.round(t/1000)+'k' : t);
+      } catch(e) { '?' }
+    " 2>/dev/null || echo "?")
+  fi
+
+  if [ "$start_epoch" -gt 0 ] 2>/dev/null; then
+    local now secs
+    now=$(date +%s)
+    secs=$(( now - start_epoch ))
+    elapsed=" · $(( secs / 60 ))m$(( secs % 60 ))s"
+  fi
+
+  printf "  ${C_CYAN:-}→${C_NC:-}  %s  •  Phase %s%s  •  %s tokens%s\n" \
+    "$feat_id" "${phase:-?}" "$task_seg" "$tokens" "$elapsed"
 }

--- a/scripts/lib/runner.sh
+++ b/scripts/lib/runner.sh
@@ -13,13 +13,14 @@
 #   - router_route_task() for stack-aware agent selection (router.sh)
 #   - cycle_gate_check() before advancing to next feature (cycle_gate.sh)
 
-# _orchestrator_watcher_start <sentinel> <watch_dir> [interval_s]
-# Launches a background heartbeat process that prints [progress] lines to stdout
-# every interval_s seconds. Tracks newly-written files under watch_dir by name.
+# _orchestrator_watcher_start <sentinel> <watch_dir> [interval_s] [feat_id]
+# Launches a background heartbeat process that prints live-phase status lines
+# every interval_s seconds. When feat_id is provided, reads status.json + cost.json
+# for richer phase/task/token context. Falls back to plain elapsed-time output.
 # PID stored at <sentinel>.pid so _orchestrator_watcher_stop can kill it.
 # Set PROGRESS_INTERVAL=0 to disable entirely.
 _orchestrator_watcher_start() {
-  local sentinel="$1" watch_dir="$2" interval="${3:-45}"
+  local sentinel="$1" watch_dir="$2" interval="${3:-45}" feat_id="${4:-}"
   [ "${interval}" -le 0 ] 2>/dev/null && return 0
   local ref="${sentinel}.ref" pid_file="${sentinel}.pid"
   local start_ts
@@ -29,13 +30,17 @@ _orchestrator_watcher_start() {
     while [ -f "$sentinel" ]; do
       sleep "$interval"
       [ -f "$sentinel" ] || break
-      elapsed=$(( $(date +%s) - start_ts ))
-      changed=$(find "$watch_dir" -newer "$ref" -type f 2>/dev/null | sort | while IFS= read -r f; do basename "$f"; done | tr '\n' ' ')
       touch "$ref"
-      if [ -n "$changed" ]; then
-        printf '  [progress] %ds elapsed — files written: %s\n' "$elapsed" "$changed"
+      if [ -n "$feat_id" ] && declare -f display_live_phase &>/dev/null; then
+        display_live_phase "$feat_id" "$start_ts"
       else
-        printf '  [progress] %ds elapsed — Claude working (no new files in last %ds)\n' "$elapsed" "$interval"
+        elapsed=$(( $(date +%s) - start_ts ))
+        changed=$(find "$watch_dir" -newer "$ref" -type f 2>/dev/null | sort | while IFS= read -r f; do basename "$f"; done | tr '\n' ' ')
+        if [ -n "$changed" ]; then
+          printf '  [progress] %ds elapsed — files written: %s\n' "$elapsed" "$changed"
+        else
+          printf '  [progress] %ds elapsed — Claude working (no new files in last %ds)\n' "$elapsed" "$interval"
+        fi
       fi
     done
   ) &
@@ -484,7 +489,8 @@ EOPRD
     _orchestrator_watcher_start \
       "$STATE_DIR/$feat_id/.watcher-active" \
       "$wt_path/tasks/prd-$feat_id" \
-      "${PROGRESS_INTERVAL:-45}"
+      "${PROGRESS_INTERVAL:-45}" \
+      "$feat_id"
   fi
 
   (cd "$wt_path" && op_timeout "${SKILL_TIMEOUT_SECONDS:-1800}" \
@@ -767,7 +773,8 @@ run_phase3_tests() {
         _orchestrator_watcher_start \
           "$STATE_DIR/$feat_id/.fix-watcher-active" \
           "$wt_path" \
-          "${PROGRESS_INTERVAL:-45}"
+          "${PROGRESS_INTERVAL:-45}" \
+          "$feat_id"
       fi
       (cd "$wt_path" && printf '%b' "$fix_prompt" | claude $model_flag $fix_perm_flag --print) 2>/dev/null || fix_exit=$?
       _orchestrator_watcher_stop "$STATE_DIR/$feat_id/.fix-watcher-active"

--- a/scripts/lib/ui.sh
+++ b/scripts/lib/ui.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# lib/ui.sh — ANSI color tokens for orchestrator terminal output
+# TTY-gated: colors emit only when stdout is a terminal.
+# Override: FM_FORCE_COLOR=1 forces colors even in pipes.
+
+if [[ -t 1 ]] || [[ "${FM_FORCE_COLOR:-}" == "1" ]]; then
+  C_RED=$'\033[0;31m'
+  C_GREEN=$'\033[0;32m'
+  C_YELLOW=$'\033[0;33m'
+  C_BLUE=$'\033[0;34m'
+  C_CYAN=$'\033[0;36m'
+  C_DIM=$'\033[2m'
+  C_BOLD=$'\033[1m'
+  C_NC=$'\033[0m'
+else
+  C_RED=''; C_GREEN=''; C_YELLOW=''; C_BLUE=''; C_CYAN=''; C_DIM=''; C_BOLD=''; C_NC=''
+fi
+export C_RED C_GREEN C_YELLOW C_BLUE C_CYAN C_DIM C_BOLD C_NC

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -48,16 +48,19 @@ RESULTS_DIR="$CONFIG_DIR/results"
 
 cd "$ROOT_DIR"
 
+# ── Colors (load early so helpers and display.sh can use them) ────
+# shellcheck source=lib/ui.sh
+source "$LIB_DIR/ui.sh"
+
 # ── Helpers (available before modules load) ──────────────────────
 
-log()    { echo "▶ [orchestrate] $*"; }
-info()   { echo "  [orchestrate] $*"; }
-err()    { echo "✗ [orchestrate] $*" >&2; }
+log()    { printf "${C_CYAN}▶${C_NC} [orchestrate] %s\n" "$*"; }
+info()   { printf "${C_DIM}  [orchestrate] %s${C_NC}\n" "$*"; }
+err()    { printf "${C_RED}✗${C_NC} [orchestrate] %s\n" "$*" >&2; }
 banner() {
-  echo ""
-  echo "═══════════════════════════════════════════════════"
-  echo "  $*"
-  echo "═══════════════════════════════════════════════════"
+  printf "\n${C_BOLD}${C_CYAN}%s${C_NC}\n" "═══════════════════════════════════════════════════"
+  printf "${C_BOLD}  %s${C_NC}\n" "$*"
+  printf "${C_BOLD}${C_CYAN}%s${C_NC}\n" "═══════════════════════════════════════════════════"
 }
 
 # ── CLI Parsing ──────────────────────────────────────────────────

--- a/scripts/orchestrator.sh
+++ b/scripts/orchestrator.sh
@@ -68,17 +68,18 @@ export BASE_BRANCH ADAPTER AUTONOMY WORKTREE_BASE BRANCH_PREFIX
 # ── source worktree manager ─────────────────────────────────────
 
 source "$SCRIPT_DIR/worktree-manager.sh"
+# shellcheck source=lib/ui.sh
+source "$SCRIPT_DIR/lib/ui.sh"
 
 # ── helpers ──────────────────────────────────────────────────────
 
-log()    { echo "▶ [orchestrator] $*"; }
-info()   { echo "  [orchestrator] $*"; }
-err()    { echo "✗ [orchestrator] $*" >&2; }
+log()    { printf "${C_CYAN}▶${C_NC} [orchestrator] %s\n" "$*"; }
+info()   { printf "${C_DIM}  [orchestrator] %s${C_NC}\n" "$*"; }
+err()    { printf "${C_RED}✗${C_NC} [orchestrator] %s\n" "$*" >&2; }
 banner() {
-  echo ""
-  echo "═══════════════════════════════════════════════════"
-  echo "  $*"
-  echo "═══════════════════════════════════════════════════"
+  printf "\n${C_BOLD}${C_CYAN}%s${C_NC}\n" "═══════════════════════════════════════════════════"
+  printf "${C_BOLD}  %s${C_NC}\n" "$*"
+  printf "${C_BOLD}${C_CYAN}%s${C_NC}\n" "═══════════════════════════════════════════════════"
 }
 
 write_status() {

--- a/tasks/prd-ux-orchestrator-progress/tasks.md
+++ b/tasks/prd-ux-orchestrator-progress/tasks.md
@@ -2,14 +2,17 @@
 
 ## Task List
 
-- [ ] 1. Add `display_backlog_table()` to `display.sh`
-- [ ] 2. Call `display_backlog_table()` at each feature-start banner in `runner.sh`
-- [ ] 3. Add `display_next_steps()` to `display.sh`
-- [ ] 4. Thread `next_feat_id` from `run_backlog()` into `run_feature()` and call `display_next_steps()`
-- [ ] 5. Improve cycle-gate block messaging in `runner.sh`
-- [ ] 6. Fix `processed` count (introduce `ran_count`) in `run_backlog()`
-- [ ] 7. Add "Ran this session" row to `display_summary()` in `display.sh`
+- [x] 1. Add `display_backlog_table()` to `display.sh`
+- [x] 2. Call `display_backlog_table()` at each feature-start banner in `runner.sh`
+- [x] 3. Add `display_next_steps()` to `display.sh`
+- [x] 4. Thread `next_feat_id` from `run_backlog()` into `run_feature()` and call `display_next_steps()`
+- [x] 5. Improve cycle-gate block messaging in `runner.sh`
+- [x] 6. Fix `processed` count (introduce `ran_count`) in `run_backlog()`
+- [x] 7. Add "Ran this session" row to `display_summary()` in `display.sh`
 - [ ] 8. Manual smoke test against stub-project
+- [x] 9. Create `scripts/lib/ui.sh` — TTY-gated color module (C_RED, C_GREEN, C_YELLOW, C_CYAN, C_DIM, C_BOLD, C_NC + FM_FORCE_COLOR override)
+- [x] 10. Color status icons in `display_backlog_table`, `display_next_steps`, `display_paused_handoff`; color the "BACKLOG [N/M done]" header
+- [x] 11. Add `display_live_phase()` to `display.sh`; wire into heartbeat loop in `runner.sh`
 
 ## Task Details
 

--- a/tasks/prd-ux-orchestrator-progress/techspec.md
+++ b/tasks/prd-ux-orchestrator-progress/techspec.md
@@ -185,10 +185,129 @@ This makes it unambiguous that `Avg` refers only to features processed in this r
 
 ---
 
+## Change 6: Color Module `scripts/lib/ui.sh`
+
+**New file:** `scripts/lib/ui.sh`
+
+TTY-gated ANSI exports. Sourced by `orchestrate.sh`, `orchestrator.sh`, and `display.sh`.
+
+```bash
+#!/bin/bash
+# lib/ui.sh — ANSI color tokens for orchestrator output
+if [[ -t 1 ]] || [[ "${FM_FORCE_COLOR:-}" == "1" ]]; then
+  C_RED='\033[0;31m'; C_GREEN='\033[0;32m'; C_YELLOW='\033[0;33m'
+  C_BLUE='\033[0;34m'; C_CYAN='\033[0;36m'; C_DIM='\033[2m'
+  C_BOLD='\033[1m'; C_NC='\033[0m'
+else
+  C_RED=''; C_GREEN=''; C_YELLOW=''; C_BLUE=''; C_CYAN=''; C_DIM=''; C_BOLD=''; C_NC=''
+fi
+export C_RED C_GREEN C_YELLOW C_BLUE C_CYAN C_DIM C_BOLD C_NC
+```
+
+Replace inline `log/info/err/banner` in `scripts/orchestrate.sh:53–61` with:
+
+```bash
+source "$SCRIPT_DIR/lib/ui.sh"
+log()    { echo -e "${C_CYAN}▶${C_NC} [orchestrate] $*"; }
+info()   { echo -e "${C_DIM}  [orchestrate] $*${C_NC}"; }
+err()    { echo -e "${C_RED}✗${C_NC} [orchestrate] $*" >&2; }
+banner() { echo -e "\n${C_BOLD}${C_CYAN}═══════════════════════════════════════════════════${C_NC}"; echo -e "${C_BOLD}  $*${C_NC}"; echo -e "${C_BOLD}${C_CYAN}═══════════════════════════════════════════════════${C_NC}"; }
+```
+
+Apply same to `scripts/orchestrator.sh` where it re-defines these helpers.
+
+---
+
+## Change 7: Colored Status Icons in `display.sh`
+
+Update the `icon()` function inside `display_backlog_table` (L64–70 of `display.sh`) to emit ANSI-colored strings. Since the surrounding code is a `node -e` heredoc, inject the ANSI vars as shell variables before the node call:
+
+```bash
+display_backlog_table() {
+  local active_feat="${1:-}"
+  [ ! -d "$STATE_DIR" ] && return
+  local c_green="${C_GREEN:-}" c_red="${C_RED:-}" c_yellow="${C_YELLOW:-}" \
+        c_cyan="${C_CYAN:-}" c_dim="${C_DIM:-}" c_bold="${C_BOLD:-}" c_nc="${C_NC:-}"
+  node -e "
+    const g='$c_green', r='$c_red', y='$c_yellow', cy='$c_cyan',
+          d='$c_dim',   bo='$c_bold', nc='$c_nc';
+    ...
+    const icon = f => {
+      if (f.id===active||f.status==='in-progress') return cy+'→'+nc;
+      if (f.status==='done'||f.status==='pr-created') return g+'✓'+nc;
+      if (f.status==='failed') return r+'✗'+nc;
+      if (f.status==='paused') return y+'⏸'+nc;
+      return d+'·'+nc;
+    };
+    const hdr = bo+cy+'  BACKLOG  ['+doneN+'/'+features.length+' done]'+nc
+              + (totalTok?' — ~'+fmtTok(totalTok)+' tokens':'');
+    ...
+  "
+}
+```
+
+Apply same colored-icon pattern to `display_next_steps` (feat_id → done line) and `display_paused_handoff` (⏸ prefix).
+
+---
+
+## Change 8: `display_live_phase()` in `display.sh`
+
+**New function in `display.sh`:**
+
+```bash
+# display_live_phase <feat_id> <start_epoch>
+# Reads $STATE_DIR/$feat_id/status.json and cost.json.
+# Prints a one-line status line suitable for repeated overwrite.
+display_live_phase() {
+  local feat_id="$1" start_epoch="${2:-0}"
+  local status_file="$STATE_DIR/$feat_id/status.json"
+  local cost_file="$STATE_DIR/$feat_id/cost.json"
+
+  local phase="?" task_idx="" total_tasks="" tokens="?" elapsed=""
+
+  if [ -f "$status_file" ]; then
+    phase=$(node -p "try{const s=JSON.parse(require('fs').readFileSync('$status_file','utf-8')); s.phase||'?'}catch(e){'?'}" 2>/dev/null || echo "?")
+    task_idx=$(node -p "try{const s=JSON.parse(require('fs').readFileSync('$status_file','utf-8')); s.task_index||''}catch(e){''}" 2>/dev/null || echo "")
+    total_tasks=$(node -p "try{const s=JSON.parse(require('fs').readFileSync('$status_file','utf-8')); s.total_tasks||''}catch(e){''}" 2>/dev/null || echo "")
+  fi
+
+  if [ -f "$cost_file" ]; then
+    local raw_tok
+    raw_tok=$(node -p "try{Math.round(JSON.parse(require('fs').readFileSync('$cost_file','utf-8')).cumulative_tokens/1000)+'k'}catch(e){'?'}" 2>/dev/null || echo "?")
+    tokens="~${raw_tok}"
+  fi
+
+  if [ "$start_epoch" -gt 0 ] 2>/dev/null; then
+    local now; now=$(date +%s)
+    local secs=$(( now - start_epoch ))
+    elapsed="$(( secs / 60 ))m$(( secs % 60 ))s"
+  fi
+
+  local task_seg=""
+  [ -n "$task_idx" ] && [ -n "$total_tasks" ] && task_seg=" · task ${task_idx}/${total_tasks}"
+
+  echo -e "  ${C_CYAN:-}→${C_NC:-}  ${feat_id}  •  Phase ${phase}${task_seg}  •  ${tokens} tokens  •  ${elapsed}"
+}
+```
+
+**Call site in `runner.sh`:** locate the `[progress]` heartbeat emitter (search for `"[progress]"` or `sleep 45` region in the watcher background loop) and replace the plain `info "[progress] …"` line with:
+
+```bash
+display_live_phase "$feat_id" "$start_time"
+```
+
+Keep the 45s cadence; `display_live_phase` gracefully falls back when files are absent.
+
+---
+
 ## Testing
 
-1. Run stub-project with 5 features in full_auto → verify backlog table appears at each feature start
-2. Kill run mid-backlog → re-run → verify "next steps" block shows correct next feature
-3. Force cycle-gate block → verify new messaging with copy-paste command appears
-4. Single-feature run (1 feature done, 0 remaining) → verify "all features complete" block
-5. `Avg` = `Total ÷ ran_count` for any subset of features processed
+1. Run stub-project with 5 features in full_auto → verify backlog table appears at each feature start (already works)
+2. Kill run mid-backlog → re-run → verify "next steps" block shows correct next feature (already works)
+3. Force cycle-gate block → verify new messaging with copy-paste command appears (already works)
+4. Single-feature run (1 feature done, 0 remaining) → verify "all features complete" block (already works)
+5. `Avg` = `Total ÷ ran_count` for any subset of features processed (already works)
+6. Run in a TTY → expect colored `▶`, `✓`, `✗`, `⏸`, `→` glyphs; header lines bold/cyan
+7. Pipe output (`| cat`) without `FM_FORCE_COLOR` → no escape bytes
+8. `FM_FORCE_COLOR=1 … | cat` → colors retained
+9. Mid-run heartbeat → `display_live_phase` line shows `Phase N · task k/m · ~Xk tokens · Nm Ns`


### PR DESCRIPTION
## Summary

- Add `scripts/lib/ui.sh`: TTY-gated ANSI color module. Colors emit only in TTY; `FM_FORCE_COLOR=1` forces colors in pipes. Exports `C_RED/GREEN/YELLOW/BLUE/CYAN/DIM/BOLD/NC`.
- Replace flat `log/info/err/banner` helpers in `orchestrate.sh` and `orchestrator.sh` with colored variants (cyan `▶`, dim info, red `✗`, bold cyan banner).
- Color status icons in `display_backlog_table` (via injected ANSI vars in the Node script), `display_next_steps`, and `display_paused_handoff`.
- Add `display_live_phase <feat_id> <start_epoch>` to `display.sh`: reads `status.json` + `cost.json` each tick and prints `→ feat • Phase N • task k/m • ~Xk tokens • Nm Ns`.
- Extend `_orchestrator_watcher_start` in `runner.sh` with optional 4th arg `feat_id`; both watcher call sites pass it, replacing the plain `[progress] Ns elapsed` pulse-check.

## Test plan

- [ ] Run `feature-marker-orchestrate run --autonomy checkpoint` in a TTY → colored `▶`, `✓`, `→`, `✗`, `⏸`, `·` glyphs; banner lines bold/cyan
- [ ] Pipe output (`| cat`) without `FM_FORCE_COLOR` → no escape bytes in output
- [ ] `export FM_FORCE_COLOR=1` then run → colors present even in pipe
- [ ] During a Claude feature run, check stdout every ~45s → `display_live_phase` line shows `Phase N · ~Xk tokens · elapsed`
- [ ] Kill mid-run and restart → heartbeat resumes reading `status.json` correctly
- [ ] Confirm `git diff --stat main feature-marker-dist/` shows no changes (skill untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
