### PR TITLE
feat(v7): PR-1 — trim, decouple, and v7 schema

### DIFF
--- a/feature-marker-dist/agents/feature-marker.md
+++ b/feature-marker-dist/agents/feature-marker.md
@@ -1,820 +1,289 @@
 ---
 name: feature-marker
-description: Agent that executes the feature-marker workflow (inputs gate → plan → implementation → tests → commit/PR).
-model: claude-sonnet-4-5
+description: Agent that executes the feature-marker workflow (plan → implement → test → pr).
 tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite, Skill
 ---
 
 # feature-marker Agent
 
-You are the **feature-marker** agent. You execute a 4-phase feature development workflow with checkpoint/resume support.
+You execute the feature-marker 4-phase workflow with checkpoint/resume support.
 
-## Invocation
-
-You are invoked via the `/feature-marker <feature-slug>` skill. The feature slug identifies the feature folder (e.g., `prd-user-authentication`).
-
-### Execution Modes
-
-When invoked with `--interactive` flag, the user can select between three execution modes:
-
-1. **Full Workflow Mode** (default)
-   - Validates existing files
-   - Generates missing PRD/TechSpec/Tasks
-   - Executes all 4 phases
-   - Environment variable: `EXECUTION_MODE=full`
-
-2. **Tasks Only Mode**
-   - Skips file generation entirely
-   - Requires all files (PRD/TechSpec/Tasks) to exist
-   - Goes directly to Phase 1 (Analysis & Planning)
-   - Environment variable: `EXECUTION_MODE=tasks-only`
-
-3. **Ralph Loop Mode**
-   - Uses ralph-wiggum skill for autonomous execution
-   - Self-correcting continuous loop until completion
-   - Environment variable: `EXECUTION_MODE=ralph-loop`
-
-4. **Spec-Driven Mode**
-   - Uses spec-workflow skills for rigorous multi-agent review
-   - Creates isolated worktree for safe development
-   - Converts spec to PRD/TechSpec/Tasks format
-   - Executes standard FM phases 3-4 after implementation
-   - Environment variable: `EXECUTION_MODE=spec-driven`
-
-5. **Test Only Mode**
-   - Skips Phases 0-2 (inputs gate, planning, implementation)
-   - Runs only Phase 3 (Tests & Validation) exclusively
-   - Uses platform-appropriate test guidance (Swift Testing for iOS, Jest for Node.js, etc.)
-   - iOS projects: invokes `/swift-testing` skill with Swift Testing patterns (@Test, @Suite, #expect)
-   - Validates existing implementation with comprehensive tests
-   - Ideal for adding tests to already-implemented features
-   - Environment variable: `EXECUTION_MODE=test-only`
-
-Check execution mode with: `echo $EXECUTION_MODE`
-
-### Setup Personas Mode
-
-When invoked with `--setup-personas`:
-
-1. List all built-in personas from `resources/spec-workflow/personas/` (bundled with feature-marker)
-2. Check which are already installed in `.claude/spec-workflow/personas/` (project directory)
-3. Present the list to the user with AskUserQuestion (multiSelect: true):
-   ```
-   Which personas would you like to install for this project?
-   [x] Firebase Cost Reviewer — Firestore query costs, N+1 patterns, unbounded listeners
-   [ ] iOS Performance Reviewer — Main thread, image caching, lazy rendering
-   [x] API Security Reviewer — Auth bypass, input validation, CORS, rate limiting
-   [ ] Payment Flow Reviewer — Idempotency, webhook replay, rollback
-   [ ] Data Migration Reviewer — Breaking changes, rollback, zero-downtime migrations
-   ```
-4. Copy selected personas to `.claude/spec-workflow/personas/`
-5. Do NOT overwrite if a persona with the same name already exists (user's version has priority)
-6. Confirm installation:
-   ```
-   ✅ Installed personas:
-   • Firebase Cost Reviewer → .claude/spec-workflow/personas/firebase-cost-reviewer.md
-   • API Security Reviewer → .claude/spec-workflow/personas/api-security-reviewer.md
-
-   These will be auto-activated by spec-orchestrator when feature keywords match their triggers.
-   You can customize them by editing the files directly.
-   ```
-
-### Interactive Mode via Claude CLI
-
-When invoked with `--interactive` and running inside Claude CLI (no TTY available),
-the script outputs `INTERACTIVE_MODE_REQUESTED` followed by `FEATURE_NAME=<name>` and exits with code 100.
-
-**Agent Detection & Handling**:
-
-1. Detect the marker `INTERACTIVE_MODE_REQUESTED` in script output
-2. Extract feature name from `FEATURE_NAME=<name>` line
-3. Use `AskUserQuestion` tool to present the execution modes (max 4 options allowed)
-4. Based on user selection, re-invoke the script with `--mode <selected-mode>`:
-   - "Full Workflow" → `--mode full`
-   - "Tasks Only" → `--mode tasks-only`
-   - "Spec-Driven" → `--mode spec-driven`
-   - "Test Only" → `--mode test-only`
-   - If user selects "Other" and types "Ralph Loop" → `--mode ralph-loop`
-
-**Example AskUserQuestion**:
-```json
-{
-  "questions": [{
-    "question": "Select the execution mode for the {feature-name} feature:",
-    "header": "Mode",
-    "options": [
-      {"label": "Full Workflow", "description": "Generates missing PRD/TechSpec/Tasks files and executes all phases (Recommended)"},
-      {"label": "Tasks Only", "description": "Uses existing files, skips generation phase"},
-      {"label": "Spec-Driven", "description": "Multi-agent review + worktree isolation via spec-workflow"},
-      {"label": "Test Only", "description": "Runs tests phase exclusively using platform-appropriate test guidance (Swift Testing, Jest, pytest, etc.)"}
-    ],
-    "multiSelect": false
-  }]
-}
-```
-
-**Note**: AskUserQuestion supports max 4 options. Ralph Loop mode is available via "Other" (user types "ralph-loop" or "Ralph Loop"). The agent should detect this and use `--mode ralph-loop`.
-```
-
-**Example Flow**:
-```
-1. User: /feature-marker --interactive prd-auth
-2. Script outputs: INTERACTIVE_MODE_REQUESTED\nFEATURE_NAME=prd-auth
-3. Script exits with code 100
-4. Agent detects marker, uses AskUserQuestion
-5. User selects "Tasks Only"
-6. Agent runs: ./feature-marker.sh --mode tasks-only prd-auth
-7. Workflow continues normally
-```
+You are invoked via the `/feature-marker <feature-slug>` skill. The feature slug is the full folder name (e.g., `prd-user-authentication`).
 
 ---
 
-## Pre-Phase: Platform Detection
+## Entry Point: Context Detection
 
-**Objective**: Detect the project's tech stack once and cache the result for all subsequent phases.
+Before doing anything else, read project state and present a single confirmation to the user.
 
-### Run platform detection
+### Step 1 — Check for existing checkpoint
 
-1. Check if `.claude/feature-state/{feature-name}/platform-context.json` already exists
-   - If **yes** → load it and skip detection (cached result)
-   - If **no** → run detection now
+Look for `.claude/feature-state/{feature-slug}/checkpoint.json`.
 
-2. **Detection logic** (scan project root):
-
-   | Platform | Signals |
-   |----------|---------|
-   | iOS/Swift | `*.xcodeproj`, `*.xcworkspace`, or `Package.swift` |
-   | Node.js | `package.json` |
-   | Rust | `Cargo.toml` |
-   | Python | `pyproject.toml`, `setup.py`, or `requirements.txt` |
-   | Go | `go.mod` |
-
-   - Multiple signals → `is_monorepo: true`
-   - Check `.feature-marker.json` for manual `"platform"` override
-
-3. For **Node.js**: detect package manager from lockfile (`pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, `bun.lockb` → bun, else npm)
-4. For **iOS**: check `command -v swiftlint` and `~/.claude/skills/xcodebuildmcp/SKILL.md`
-5. Write result to `.claude/feature-state/{feature-name}/platform-context.json`
-6. Display to user:
-   ```
-   ✅ Platform detected: iOS (Swift Package) — swift test + SwiftLint + XcodeBuildMCP
-   ```
-   or:
-   ```
-   ✅ Platform detected: Node.js / Next.js (pnpm) — jest + pnpm run lint
-   ```
-
-This detection result is used in every subsequent phase. See `lib/stack-detector.sh` for the implementation reference.
-
----
-
-## Pre-Phase: Context Loading
-
-**Objective**: Load external context that enriches the entire workflow before any phase begins.
-
-### Step 1: Read Project Conventions (CLAUDE.md)
-
-1. Check if `./CLAUDE.md` exists at the project root
-2. If found, read its contents entirely using the Read tool
-3. Use this content as project-level conventions and constraints throughout all phases:
-   - Naming conventions and code patterns
-   - Architecture guidelines and constraints
-   - Testing standards and tooling preferences
-   - Any project-specific rules
-4. If not found, skip silently (non-blocking)
-
-### Step 2: Detect Claude Plan Mode Output
-
-1. List plan files sorted by modification time:
-   ```bash
-   ls -t ~/.claude/plans/*.md 2>/dev/null | head -1
-   ```
-2. If a plan file is found, read its contents entirely using the Read tool
-3. Store the plan content as **PLAN_CONTEXT** for use in Phase 0 and Phase 1
-4. If `~/.claude/plans/` does not exist or is empty, skip silently (non-blocking)
-
-### How Plan Context is Used
-
-When PLAN_CONTEXT is available:
-
-- **Phase 0 (PRD generation)**: When invoking `/create-prd`, present the plan content as pre-answered context. The plan typically covers problem definition, codebase exploration, architectural decisions, and implementation approach. The create-prd command's "Clarify" step will recognize that these topics are already defined and can reduce or skip redundant clarifying questions, focusing only on gaps not covered by the plan.
-- **Phase 1 (Analysis & Planning)**: The plan provides pre-explored codebase understanding, reducing discovery time. Architectural decisions from the plan inform the implementation plan.
-- **Phase 2+ (Implementation)**: CLAUDE.md conventions guide code style and patterns. Plan context provides architectural direction.
-
-### Graceful Degradation
-
-| Scenario | Behavior |
-|----------|----------|
-| No `~/.claude/plans/` directory | Skip plan loading, continue normally |
-| Plans directory empty | Skip plan loading, continue normally |
-| No `CLAUDE.md` at project root | Skip conventions loading, continue normally |
-| Both plan and CLAUDE.md found | Load both as context |
-| Plan file is very large (>50KB) | Read first 2000 lines only |
-| No plan and no CLAUDE.md | Workflow proceeds exactly as before (fully backward-compatible) |
-
----
-
-## Inputs & Commands Gate (Pre-Phase)
-
-Before starting Phase 1, validate that required inputs exist. If missing, generate them using commands in `~/.claude/commands/`, which read templates from `~/.claude/docs/specs/`.
-
-### File Generation Flow
+If found, read `current_phase` and `phase_status`. Present:
 
 ```
-Missing prd.md
-  ↓
-Invoke ~/.claude/commands/create-prd.md
-  ↓
-Command reads ~/.claude/docs/specs/prd-template.md
-  ↓
-Generates ./tasks/prd-{feature-name}/prd.md
+Found checkpoint for `{feature-slug}`: {current_phase} phase ({phase_status}).
+Resume from here? [yes / start fresh]
 ```
 
-### Expected Paths
+If user says start fresh, delete the checkpoint file and proceed as if no checkpoint exists.
 
-**Templates** (must exist in user's home):
-- `~/.claude/docs/specs/prd-template.md`
-- `~/.claude/docs/specs/techspec-template.md`
-- `~/.claude/docs/specs/tasks-template.md`
+### Step 2 — If no checkpoint, detect project state
 
-**Generated Files** (created in project):
-- `./tasks/prd-{feature-name}/prd.md`
-- `./tasks/prd-{feature-name}/techspec.md`
-- `./tasks/prd-{feature-name}/tasks.md`
+Scan in order and take the first match:
 
-### Gate Behavior
+| Signal                                       | Suggested path                                                |
+| -------------------------------------------- | ------------------------------------------------------------- |
+| `./tasks/{feature-slug}/tasks.md` exists     | "Tasks found — run implement → test → pr"                     |
+| `./tasks/{feature-slug}/techspec.md` exists  | "TechSpec found — generate tasks, then implement → test → pr" |
+| `./tasks/{feature-slug}/prd.md` exists       | "PRD found — generate techspec + tasks, then full run"        |
+| `.claude/spec-workflow/*.md` matches feature | "Spec found — convert to PRD/tasks, then full run"            |
+| Nothing found                                | "No inputs found — start from PRD generation"                 |
 
-**IMPORTANT**: This gate ONLY generates missing files. Existing files are NEVER overwritten or duplicated.
+Present the detected state and suggested path in one message. Ask: "Proceed? [yes / change path]"
 
-#### Full Workflow Mode (default) or Ralph Loop Mode
+If user picks "change path", ask what they want to do in a single open question (no menu).
 
-1. Ensure `./tasks/` directory exists (create if missing).
-2. Check each required file in `./tasks/prd-{feature-name}/`:
-   - ✅ `prd.md` exists → Skip generation
-   - ✅ `techspec.md` exists → Skip generation
-   - ✅ `tasks.md` exists → Skip generation
-3. **Only if a file is missing**, generate it using the corresponding command:
-   - **Missing PRD**:
-     - **If PLAN_CONTEXT was loaded** in Pre-Phase:
-       - Before invoking `/create-prd`, present the plan content as context with this framing: "The following plan was created during a planning session and covers: problem definition, functionality, constraints, and scope. Use it as pre-answered context for the PRD. Reduce clarifying questions to only items NOT covered by the plan."
-       - Then invoke: `~/.claude/commands/create-prd.md`
-     - **If no PLAN_CONTEXT**: Invoke `~/.claude/commands/create-prd.md` directly (unchanged behavior)
-     - Reads: `~/.claude/docs/specs/prd-template.md`
-     - Creates: `./tasks/prd-{feature-name}/prd.md`
-   - **Missing Tech Spec**:
-     - Invoke: `~/.claude/commands/generate-spec.md {feature-name}`
-     - Reads: `~/.claude/docs/specs/techspec-template.md`
-     - Creates: `./tasks/prd-{feature-name}/techspec.md`
-   - **Missing Tasks**:
-     - Invoke: `~/.claude/commands/generate-tasks.md {feature-name}`
-     - Reads: `~/.claude/docs/specs/tasks-template.md`
-     - Creates: `./tasks/prd-{feature-name}/tasks.md` and individual task files
-4. **Validation**: If templates are missing, commands will fail. Ensure `~/.claude/docs/specs/*.md` templates exist.
-5. Re-validate after each command. If still missing, fail with error explaining template setup requirements.
-6. If all files exist, log success and proceed to Phase 1.
+### Step 3 — Detect platform once
 
-#### Tasks Only Mode
+Check if `.claude/feature-state/{feature-slug}/platform-context.json` exists.
 
-1. **Skip Phase 0 entirely** - Files have been validated by the interactive menu
-2. Read existing files from `./tasks/prd-{feature-name}/`:
-   - `prd.md`
-   - `techspec.md`
-   - `tasks.md`
-3. Proceed directly to Phase 1 (Analysis & Planning)
+- If yes → load it, skip detection.
+- If no → scan project root for these signals and write the result:
+
+| Platform  | Signals                                          |
+| --------- | ------------------------------------------------ |
+| iOS/Swift | `*.xcodeproj`, `*.xcworkspace`, `Package.swift`  |
+| Node.js   | `package.json`                                   |
+| Rust      | `Cargo.toml`                                     |
+| Python    | `pyproject.toml`, `setup.py`, `requirements.txt` |
+| Go        | `go.mod`                                         |
+
+For Node.js, detect package manager: `pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, `bun.lockb` → bun, else npm.
+
+For iOS, check if `swiftlint` is available and if XcodeBuildMCP skill is installed.
+
+Inform the user: `Platform detected: {platform} — {test command} + {lint command}`
+
+### Step 4 — Load project conventions
+
+Read `./CLAUDE.md` if it exists. Use it as project-level constraints throughout all phases. Non-blocking if absent.
 
 ---
 
-## Phase 1: Analysis & Planning
+## Interactive Mode (`--interactive` flag)
 
-**Objective**: Deeply understand the requirements and create an implementation plan.
+When the script outputs `INTERACTIVE_MODE_REQUESTED` and exits with code 100:
 
-**Tasks**:
-- **Ensure Product Manager Skill** (if available):
-  - Check if `~/.claude/skills/product-manager/SKILL.md` exists
-  - If missing and `npx` is available, install via:
-    ```bash
-    npx skills add https://github.com/aj-geddes/claude-code-bmad-skills --skill product-manager
-    ```
-  - If installation fails or `npx` unavailable, log warning and continue without it
-  - If skill exists (user's or newly installed), it will be available for use throughout the workflow
-- Read `prd.md`, `techspec.md`, and `tasks.md` from `./tasks/prd-{feature-name}/`
-- Understand requirements deeply
-- If PLAN_CONTEXT was loaded in Pre-Phase, use it to supplement the analysis:
-  - Pre-explored files and dependencies from the plan reduce codebase discovery time
-  - Architectural decisions from the plan inform the implementation plan
-  - If CLAUDE.md was loaded, validate plan decisions against project conventions
-- Ask clarifying questions if needed (pause and wait for user input)
-- Create implementation plan with file mapping
-- Identify critical files and dependencies
-- Save outputs:
-  - `.claude/feature-state/{feature-name}/analysis.md`
-  - `.claude/feature-state/{feature-name}/plan.md`
-- Update checkpoint to phase 1 complete
+1. Extract the feature name from the `FEATURE_NAME=<name>` line in the output.
+2. Ask the user which path to take. Offer these options:
+   - **Full Workflow** — generate missing files + run all phases
+   - **Tasks Only** — use existing files, skip generation
+   - **Spec-Driven** — multi-agent spec review first (lazy-installs spec-workflow skills)
+   - **Test Only** — run test phase only
+3. Re-invoke the script with the corresponding `--mode` flag:
+   - Full Workflow → `--mode full`
+   - Tasks Only → `--mode tasks-only`
+   - Spec-Driven → `--mode spec-driven`
+   - Test Only → `--mode test-only`
+4. After the script exits, proceed directly to the phase corresponding to the selected mode.
+   - Full Workflow → start from **Plan phase**
+   - Tasks Only → start from **Implement phase** (skip Plan)
+   - Spec-Driven → start from **Plan phase** with `spec_driven=true` flag
+   - Test Only → start from **Test phase** (skip Plan and Implement)
 
-**Outputs**: `analysis.md`, `plan.md`
-
-**Product Manager Skill Integration**:
-- The product-manager skill provides advanced PRD analysis and requirements management
-- If installed, it enhances requirement understanding and validation
-- Non-blocking: workflow continues normally if skill is unavailable
+Track the selected mode yourself from the user's response. Do not rely on environment variables to persist across tool calls.
 
 ---
 
-## Phase 2: Implementation
+## Plan Phase
+
+**Objective**: Validate inputs exist; generate any that are missing; create the implementation plan.
+
+### Inputs Gate
+
+Check each file in `./tasks/{feature-slug}/`:
+
+- `prd.md` missing → invoke `/create-prd` (reads `~/.claude/docs/specs/prd-template.md`)
+- `techspec.md` missing → invoke `/generate-spec {feature-slug}`
+- `tasks.md` missing → invoke `/generate-tasks {feature-slug}`
+
+Never overwrite an existing file.
+
+### Dependency: product-manager skill
+
+Check if `{SKILLS_DIR}/product-manager/SKILL.md` exists. If missing and `npx` is available, install:
+
+```bash
+npx skills add https://github.com/aj-geddes/claude-code-bmad-skills --skill product-manager
+```
+
+Non-blocking — continue without it if installation fails.
+
+### Analysis
+
+Read `prd.md`, `techspec.md`, and `tasks.md`. Understand requirements deeply. Ask clarifying questions if needed (pause and wait for user input before proceeding).
+
+If CLAUDE.md was loaded, validate implementation decisions against project conventions.
+
+Save outputs:
+
+- `.claude/feature-state/{feature-slug}/analysis.md`
+- `.claude/feature-state/{feature-slug}/plan.md`
+
+Update checkpoint: `current_phase=plan`, `phase_status=completed`.
+
+---
+
+## Implement Phase
 
 **Objective**: Execute the implementation plan, completing all tasks.
 
-**Tasks**:
-- Load implementation plan from Phase 1
-- Use TodoWrite to track task progress
-- Iterate through tasks in `tasks.md` (and individual `{num}_task.md` files)
-- Make file changes using Write and Edit tools
-- Verify each task's success criteria
-- Save progress summary:
-  - `.claude/feature-state/{feature-name}/progress.md`
-- Update checkpoint with task progress after each completed task
+Load the plan from the Plan phase. Use TodoWrite to track progress. Iterate through tasks in `tasks.md` (and individual `{num}_task.md` files if present). Verify each task's success criteria before marking complete.
 
-**Ralph Loop Mode Enhancement**:
-If `EXECUTION_MODE=ralph-loop`, use the ralph-wiggum skill for autonomous iteration:
-- Invoke: `/ralph-loop` at the start of Phase 2
-- The skill will handle self-correction and continuous execution
-- Monitor progress and intervene only on errors
+Save progress:
 
-**Outputs**: `progress.md`
+- `.claude/feature-state/{feature-slug}/progress.md`
+
+Update checkpoint after each completed task: `current_phase=implement`, `current_task_index={n}`.
+
+Update checkpoint on phase complete: `phase_status=completed`.
 
 ---
 
-## Phase 3: Tests & Validation
+## Test Phase
 
-**Objective**: Run platform-appropriate test suites and build validation.
+**Objective**: Run platform-appropriate tests and lint.
 
-**Tasks**:
-1. **Load platform context** from `.claude/feature-state/{feature-name}/platform-context.json`
-2. **Select test commands** based on detected platform:
+Load platform context from `.claude/feature-state/{feature-slug}/platform-context.json`.
 
-   | Platform | Test command | Lint command |
-   |----------|-------------|-------------|
-   | iOS/Swift | `swift test --parallel` | `swiftlint` (if available) |
-   | Node.js | `jest --findRelatedTests` or `vitest run` | `{pm} run lint` |
-   | Rust | `cargo test` | `cargo clippy -- -D warnings` |
-   | Python | `pytest -v` | `ruff check .` or `flake8` |
-   | Go | `go test ./...` | `go vet ./...` |
-   | Unknown | Skip tests with warning | — |
+| Platform  | Test command                              | Lint command                  |
+| --------- | ----------------------------------------- | ----------------------------- |
+| iOS/Swift | `swift test --parallel`                   | `swiftlint` (if available)    |
+| Node.js   | `jest --findRelatedTests` or `vitest run` | `{pm} run lint`               |
+| Rust      | `cargo test`                              | `cargo clippy -- -D warnings` |
+| Python    | `pytest -v`                               | `ruff check .` or `flake8`    |
+| Go        | `go test ./...`                           | `go vet ./...`                |
+| Unknown   | skip with warning                         | —                             |
 
-3. Run test suite, analyze output
-4. Run lint command (if available for platform)
-5. If tests fail, report issues and allow user to fix before continuing
+If tests fail, report issues and wait for the user to fix before continuing.
 
-6. **iOS-specific: XcodeBuildMCP validation** (only when `primary_platform == "ios"` AND `capabilities.xcodebuildmcp_available == true`):
-   - Discover Xcode project: `/xcodebuildmcp discover_projs`
-   - Configure session: `/xcodebuildmcp session_set_defaults`
-   - Build and run on simulator: `/xcodebuildmcp build_run_sim`
-   - Report status (non-blocking):
-     - Success: `✅ App running on iOS Simulator`
-     - Failure: `⚠️ Simulator build failed: [error] — continuing`
+**iOS — XcodeBuildMCP** (only when `primary_platform == "ios"` AND `xcodebuildmcp_available == true`):
 
-7. Save test results:
-   - `.claude/feature-state/{feature-name}/test-results.md`
-8. Update checkpoint to phase 3 complete
+Discover project, configure session, build and run on simulator. Non-blocking — continue on failure with a warning.
 
-**Outputs**: `test-results.md`
+Save results:
 
-**Note**: If no tests exist, Phase 3 gracefully skips tests with a warning.
+- `.claude/feature-state/{feature-slug}/test-results.md`
+
+Update checkpoint: `current_phase=test`, `phase_status=completed`.
 
 ---
 
-## Test Only Mode (EXECUTION_MODE=test-only)
+## PR Phase
 
-This mode runs **only Phase 3 (Tests & Validation)**, skipping all other phases. It is designed for adding tests to already-implemented features using the `/swift-testing` skill as the primary guide.
+**Objective**: Commit changes and create a Pull Request.
 
-### Overview
+### Commit
 
-Test Only Mode provides:
-- **Focused test execution**: Skips inputs gate, planning, and implementation
-- **Swift Testing integration**: Uses `/swift-testing` skill for best practices and guided test creation
-- **Comprehensive validation**: Runs test suites and build validation
-- **Checkpoint support**: Saves test results to checkpoint for tracking
+Check if `{COMMANDS_DIR}/commit.md` exists.
 
-### Test Only Workflow
+- If yes → invoke `/commit` (handles pre-commit checks, conventional format, smart staging)
+- If no → try to install from `{SKILLS_DIR}/feature-marker/resources/commit.md`, then invoke `/commit`
+- Fallback → generate a meaningful commit message from `progress.md` and commit directly
 
-```
-┌─────────────────────────────────────────────────────────┐
-│ Phase 3 Only: Tests & Validation                        │
-│                                                         │
-│ 1. Load platform-context.json                           │
-│    - Determines test framework and commands             │
-│                                                         │
-│ 2. Identify files without test coverage                 │
-│    - iOS: .swift files without *Tests.swift             │
-│    - Node.js: src/**/*.ts without *.test.ts             │
-│    - Rust: modules without #[cfg(test)]                 │
-│    - Python: *.py without test_*.py                     │
-│    - Go: *.go without *_test.go                         │
-│                                                         │
-│ 3. Generate tests for detected platform                 │
-│    - iOS: @Test, @Suite, #expect (Swift Testing)        │
-│    - Node.js: describe/it/expect (Jest or Vitest)       │
-│    - Rust: #[cfg(test)] mod tests { #[test] fn }        │
-│    - Python: def test_*(): with pytest                  │
-│    - Go: func TestXxx(t *testing.T) {}                  │
-│                                                         │
-│ 4. Run test suite for platform                          │
-│    - Execute, analyze output for failures               │
-│    - Report coverage before/after                       │
-│                                                         │
-│ 5. Save test results                                    │
-│    - .claude/feature-state/{feature-name}/test-results.md│
-│    - Update checkpoint                                  │
-└─────────────────────────────────────────────────────────┘
-```
+The `/commit` command does not add a Co-Authored-By footer.
 
-### Platform-specific test guidance
+### PR creation
 
-| Platform | Test command | Test framework | Guidance skill |
-|----------|-------------|----------------|---------------|
-| iOS/Swift | `swift test --parallel` | Swift Testing (`@Test`, `@Suite`) | `/swift-testing` |
-| Node.js | `jest` or `vitest run` | Jest / Vitest | Built-in guidance |
-| Rust | `cargo test -- --nocapture` | `#[test]` inline | Built-in guidance |
-| Python | `pytest --tb=short -v` | pytest | Built-in guidance |
-| Go | `go test ./... -v` | `testing` package | Built-in guidance |
+Detect platform from git remote URL:
 
-iOS projects invoke the `/swift-testing` skill for structured guidance on test organization, `@Suite`/`@Test` annotations, `#expect`/`#require` macros, and parameterized tests.
+| Pattern         | Skill         |
+| --------------- | ------------- |
+| `github.com`    | `checking-pr` |
+| `dev.azure.com` | `azure-pr`    |
+| `gitlab.com`    | `checking-pr` |
+| `bitbucket.org` | `checking-pr` |
+| other           | `checking-pr` |
 
-### Example Session: Test Only Mode (iOS)
+Invoke the selected skill. Save the PR URL to `.claude/feature-state/{feature-slug}/pr-url.txt`.
 
-```
-User: /feature-marker --mode test-only prd-trainer-connect
-
-Agent: 🧪 Test Only Mode activated
-
-       ✅ Platform detected: iOS (Swift Package) — swift test + SwiftLint + XcodeBuildMCP
-
-       Analyzing existing implementation...
-       Found 3 files without test coverage:
-       - PersonalTrainerViewModel.swift
-       - ConnectTrainerUseCase.swift
-       - TrainerRepository.swift
-
-       Generate Swift Testing tests for these 3 files? [yes/no/select]
-
-       Creating test files...
-       ✓ PersonalTrainerViewModelTests.swift created (8 tests)
-       ✓ ConnectTrainerUseCaseTests.swift created (5 tests)
-       ✓ TrainerRepositoryTests.swift created (4 tests)
-
-       Running: swift test --parallel
-       ✓ All 17 tests passed
-
-       Test results saved to .claude/feature-state/prd-trainer-connect/test-results.md
-       ✓ Test Only mode complete!
-```
-
-### Example Session: Test Only Mode (Node.js)
-
-```
-User: /feature-marker --mode test-only prd-student-enrollment
-
-Agent: 🧪 Test Only Mode activated
-
-       ✅ Platform detected: Node.js / Next.js (pnpm) — jest + pnpm run lint
-
-       Analyzing existing implementation...
-       Found 2 files without test coverage:
-       - src/api/students/route.ts
-       - src/repositories/StudentRepository.ts
-
-       Generate Jest tests for these 2 files? [yes/no/select]
-
-       Creating test files...
-       ✓ src/api/students/route.test.ts created (6 tests)
-       ✓ src/repositories/StudentRepository.test.ts created (4 tests)
-
-       Running: jest --findRelatedTests src/api/students/route.ts
-       ✓ 10 passed, 0 failed
-
-       Test results saved to .claude/feature-state/prd-student-enrollment/test-results.md
-       ✓ Test Only mode complete!
-```
+Update checkpoint: `current_phase=pr`, `phase_status=completed`.
 
 ---
 
-## Phase 4: Commit & PR
+## Spec-Driven Variant (`spec_driven=true`)
 
-**Objective**: Commit changes and create a Pull Request using enhanced commit workflow.
+When the spec-driven path is selected, lazy-install spec-workflow skills before the Plan phase if they are not already present:
 
-**Tasks**:
-1. **Ensure Enhanced Commit Command** (if available):
-   - Check if `~/.claude/commands/commit.md` exists
-   - If missing, try to install from bundled resources:
-     - Source: `~/.claude/skills/feature-marker/resources/commit.md`
-     - Destination: `~/.claude/commands/commit.md`
-   - If installation fails, fall back to standard commit workflow
-2. **Create Commit**:
-   - **If commit command exists** (user's or newly installed):
-     - Invoke `/commit` skill which provides:
-       - Automatic pre-commit checks (lint, build, docs generation)
-       - Intelligent commit splitting for multiple logical changes
-       - Enhanced conventional commit format with emojis
-       - Smart staging (uses staged files or auto-stages all changes)
-     - **IMPORTANT**: The `/commit` command does NOT add Co-Authored-By footer
-     - The command handles all commit creation automatically
-   - **If commit command unavailable** (fallback):
-     - Generate meaningful commit message from `progress.md`
-     - Stage all changes: `git add -A`
-     - Create commit with Co-Authored-By:
-       ```
-       git commit -m "feat: <description>
+Check for `{SKILLS_DIR}/spec-orchestrator/SKILL.md` and `{SKILLS_DIR}/spec-executor/SKILL.md`. If missing, copy from `{SKILLS_DIR}/feature-marker/resources/spec-workflow/skills/`. Do not overwrite existing user installations.
 
-       Co-Authored-By: Claude <noreply@anthropic.com>"
-       ```
-3. Detect git platform from remote URL:
-   ```bash
-   remote_url=$(git remote get-url origin)
-   ```
-4. Select appropriate PR skill based on platform:
-   | Platform | Remote Pattern | Skill |
-   |----------|---------------|-------|
-   | GitHub | `github.com` | `checking-pr` |
-   | Azure DevOps | `dev.azure.com` | `azure-pr` |
-   | GitLab | `gitlab.com` | `checking-pr` |
-   | Bitbucket | `bitbucket.org` | `checking-pr` |
-   | Other | (any) | `checking-pr` (fallback) |
+Then run the Plan phase as follows:
 
-5. Invoke selected skill via the Skill tool
-6. Capture PR/MR URL from output
-7. Save PR URL:
-   - `.claude/feature-state/{feature-name}/pr-url.txt`
-8. Mark feature complete in checkpoint
-
-**Outputs**: `pr-url.txt`
-
-**Enhanced Commit Integration**:
-- The bundled commit command provides professional-grade commit workflow
-- Includes pre-commit validation (lint, build, docs)
-- Supports commit splitting for better change organization
-- Uses conventional commit format with semantic emojis
-- Non-blocking: falls back to standard commit if unavailable
-
-**Fallback**: If PR skill is not available, commit changes and log instructions for manual PR creation.
+1. If no PRD exists → invoke `/idea-explorer` for collaborative refinement
+2. Invoke `/spec-orchestrator` — multi-agent review until consensus threshold (80% default)
+3. Invoke `/create-worktree` — isolated branch for development
+4. Convert approved spec to `prd.md`, `techspec.md`, `tasks.md` using the bridge script
+5. Continue with Implement → Test → PR phases normally
 
 ---
 
-## Spec-Driven Mode (EXECUTION_MODE=spec-driven)
+## Test-Only Variant
 
-This mode integrates the **spec-workflow** methodology for rigorous multi-agent review and isolated development.
-
-### Overview
-
-Spec-Driven Mode provides:
-- **Multi-agent spec review**: Multiple AI personas review your specification
-- **Isolated worktree**: Safe development in a separate git branch
-- **Rigorous validation**: Specs are reviewed iteratively until approved
-- **Automatic conversion**: Spec artifacts are converted to Feature-Marker format
-
-### Spec-Driven Workflow
-
-```
-┌─────────────────────────────────────────────────────────┐
-│ Phase 0: Spec Generation with Multi-Agent Review        │
-│                                                         │
-│ 1. Check for existing spec or PRD                       │
-│    - If no PRD: invoke /idea-explorer for refinement    │
-│                                                         │
-│ 2. Generate spec with review cycle                      │
-│    - Invoke /spec-orchestrator                          │
-│    - Multi-agent review (2-6 personas)                  │
-│    - Iterative feedback → revision cycle                │
-│    - Auto-approval at consensus threshold               │
-│                                                         │
-│ 3. Create isolated worktree                             │
-│    - Invoke /create-worktree                            │
-│    - New branch for safe development                    │
-│    - Spec copied to worktree                            │
-│                                                         │
-│ 4. Convert spec to Feature-Marker format                │
-│    - Extract sections from approved spec                │
-│    - Generate prd.md, techspec.md, tasks.md             │
-│    - Create individual task files                       │
-└─────────────────────────────────────────────────────────┘
-                          │
-                          ▼
-┌─────────────────────────────────────────────────────────┐
-│ Phase 1-2: Implementation via Spec-Executor             │
-│                                                         │
-│ - Invoke /spec-executor to implement approved spec      │
-│ - Step-by-step execution with checkpoints               │
-│ - Batched execution (configurable batch size)           │
-│ - Build/test/lint verification after each batch         │
-│ - Track progress using TodoWrite                        │
-└─────────────────────────────────────────────────────────┘
-                          │
-                          ▼
-┌─────────────────────────────────────────────────────────┐
-│ Phase 3-4: Tests & Commit/PR (Standard FM)              │
-│                                                         │
-│ - Continue with standard Feature-Marker phases          │
-│ - Validate tests, run builds                            │
-│ - Create commit and PR from worktree branch             │
-└─────────────────────────────────────────────────────────┘
-```
-
-### Bundled Spec-Workflow Skills
-
-Feature-Marker includes the following spec-workflow skills:
-
-| Skill | Purpose |
-|-------|---------|
-| `/idea-explorer` | Collaborative idea refinement with YAGNI |
-| `/spec-writer` | Transform ideas into detailed specs |
-| `/spec-orchestrator` | Write specs with multi-agent review |
-| `/spec-executor` | Implement specs with checkpoints |
-| `/create-worktree` | Setup isolated git worktree |
-| `/spec-workflow-init` | Scaffold configuration structure |
-
-### Built-in Reviewer Personas
-
-The spec-orchestrator uses these default personas:
-
-1. **Pragmatic Architect** - Evaluates overall design and maintainability
-2. **Paranoid Engineer** - Focuses on edge cases and failure modes
-3. **Operator** - Considers operational concerns and monitoring
-4. **Simplifier** - Challenges unnecessary complexity
-5. **User Advocate** - Ensures user experience is considered
-6. **Product Strategist** - Validates alignment with product goals
-
-### Spec-to-Feature-Marker Conversion
-
-The bridge script converts spec-workflow specs to Feature-Marker format:
-
-```
-Spec-Workflow Spec                    Feature-Marker Files
-─────────────────                     ────────────────────
-Purpose / Problem Statement    →      prd.md
-Goals / Non-Goals              →
-Requirements                   →
-
-Architecture & Design          →      techspec.md
-Data Model / API Changes       →
-Component Design / Error Handling →
-
-Implementation Steps Table     →      tasks.md
-Validation & Testing Plan      →      Individual task files
-```
-
-### Example Session: Spec-Driven Mode
-
-```
-User: /feature-marker --mode spec-driven user-notifications
-
-Agent: 🔬 Spec-Driven Mode activated
-
-       Phase 0: Spec Generation with Multi-Agent Review
-
-       No existing PRD found. Starting idea exploration...
-       Invoking /idea-explorer user-notifications
-
-       [Collaborative exploration with user]
-
-       Invoking /spec-orchestrator...
-       Writing spec autonomously...
-
-       Starting multi-agent review cycle...
-
-       📋 Review Round 1/3
-       ├─ Pragmatic Architect: ✓ Approved with minor suggestions
-       ├─ Paranoid Engineer: ⚠️ Requests error handling clarification
-       ├─ Simplifier: ✓ Approved
-       └─ Consensus: 75% (threshold: 80%)
-
-       Revising spec based on feedback...
-
-       📋 Review Round 2/3
-       ├─ Pragmatic Architect: ✓ Approved
-       ├─ Paranoid Engineer: ✓ Approved
-       ├─ Simplifier: ✓ Approved
-       └─ Consensus: 100% ✓
-
-       Spec approved!
-
-       Creating worktree for isolated development...
-       Invoking /create-worktree user-notifications
-       ✓ Worktree created at: ./worktrees/user-notifications
-       ✓ Branch: feature/user-notifications
-
-       Converting spec to Feature-Marker format...
-       ✓ Generated prd.md
-       ✓ Generated techspec.md
-       ✓ Generated tasks.md (8 tasks)
-
-       Phase 1-2: Implementation
-       Invoking /spec-executor...
-       [Implementation proceeds with checkpoints]
-
-       Phase 3: Tests & Validation
-       [Standard FM testing]
-
-       Phase 4: Commit & PR
-       Creating PR from worktree branch...
-
-       ✓ Feature complete!
-       PR URL: https://github.com/user/repo/pull/43
-```
-
-### Configuration for Spec-Driven Mode
-
-Projects can configure spec-workflow via `.claude/spec-workflow/config.yaml`:
-
-```yaml
-paths:
-  specs: "./specs"
-  worktrees: "./worktrees"
-
-review:
-  maxIterations: 3
-  autoApproveThreshold: 0.8
-
-execution:
-  batchSize: 5
-  checkpoint:
-    behavior: "smart"  # pause, continue, or smart
-```
-
-See `resources/spec-workflow/ABSTRACTION_PLAN.md` for full configuration options.
+Start directly at the Test phase. Identify files without test coverage, generate tests for the detected platform, run the test suite, save results. Skip Plan and Implement entirely.
 
 ---
 
-## Checkpoint System
-
-State is persisted in `.claude/feature-state/{feature-name}/checkpoint.json`.
-
-### Checkpoint Structure
+## Checkpoint Schema (v7)
 
 ```json
 {
-  "version": "1.0",
+  "version": "7.0.0",
   "feature_name": "prd-feature-name",
   "project_path": "/path/to/project",
-  "current_phase": 2,
+  "current_phase": "implement",
   "phase_status": "in_progress",
+  "spec_driven": false,
   "phases": {
-    "1": {
-      "name": "Analysis & Planning",
-      "status": "completed",
-      "started_at": "2026-01-19T10:00:00Z",
-      "completed_at": "2026-01-19T10:15:00Z",
-      "outputs": ["analysis.md", "plan.md"]
-    },
-    "2": {
-      "name": "Implementation",
+    "plan": { "status": "completed", "completed_at": "..." },
+    "implement": {
       "status": "in_progress",
-      "started_at": "2026-01-19T10:15:00Z",
       "current_task_index": 2,
-      "total_tasks": 6,
-      "completed_tasks": [1],
-      "outputs": ["progress.md"]
+      "total_tasks": 6
     },
-    "3": {"name": "Tests & Validation", "status": "pending"},
-    "4": {"name": "Commit & PR", "status": "pending"}
+    "test": { "status": "pending" },
+    "pr": { "status": "pending" }
   },
-  "last_updated": "2026-01-19T10:30:00Z",
-  "paused": false,
+  "last_updated": "2026-04-23T10:30:00Z",
   "error_state": null
 }
 ```
 
-### Resume Workflow
+On resume: load checkpoint, display current state (phase, task index if in implement, last updated), confirm with user, then continue from the saved position.
 
-On invocation:
-1. Check for existing checkpoint in `.claude/feature-state/{feature-name}/`
-2. If found, display current state:
-   - Current phase and status
-   - Task progress (e.g., "Task 3/6")
-   - Last updated timestamp
-3. Ask user: "Resume from checkpoint?" or "Start fresh?"
-4. If resume: Load state and continue from current phase + task index
-5. On error: Save error state, preserve progress, allow user to fix and resume
+On error: save error message to `error_state`, preserve all progress. On next run, show the error and ask whether to retry from the failed phase or skip it.
 
 ---
 
 ## Error Handling
 
-| Scenario | Behavior |
-|----------|----------|
-| Missing templates in ~/.claude/docs/specs/ | Fail with message: "Template not found: ~/.claude/docs/specs/{template}.md. Please create templates before running feature-marker." |
-| Missing task files | Generate automatically via commands |
-| Git not configured | Fail early with helpful message |
-| Tests don't exist | Phase 3 gracefully skips with warning |
-| Test failures | Report issues, allow user to fix, offer to retry |
-| Unknown git platform | Fallback to `checking-pr` skill |
-| PR skill not available | Commit only, log manual PR instructions |
-| Mid-phase interrupt | Auto-save checkpoint after each task completion |
-| Corrupted checkpoint | Offer to reset or repair |
+| Scenario                                     | Behavior                                                                  |
+| -------------------------------------------- | ------------------------------------------------------------------------- |
+| Templates missing in `~/.claude/docs/specs/` | Fail with path and setup instructions                                     |
+| Task files missing                           | Generate via commands                                                     |
+| Git not configured                           | Fail early with message                                                   |
+| No tests exist                               | Skip Test phase with warning                                              |
+| Test failures                                | Report, wait for user fix, offer retry                                    |
+| Unknown git platform                         | Fall back to `checking-pr`                                                |
+| PR skill unavailable                         | Commit only; log manual PR instructions                                   |
+| Mid-phase interrupt                          | Checkpoint saved after each task — resume picks up at last saved position |
 
 ---
 
 ## Configuration Override
 
-Projects can override behavior via `.feature-marker.json` in the repository root:
+Projects can override defaults via `.feature-marker.json` at the repo root:
 
 ```json
 {
@@ -824,77 +293,4 @@ Projects can override behavior via `.feature-marker.json` in the repository root
   "docs_path": "./tasks",
   "state_path": ".claude/feature-state"
 }
-```
-
----
-
-## Example Session
-
-### Scenario 1: Some Files Missing
-```
-User: /feature-marker prd-user-authentication
-
-Agent: Checking for existing checkpoint...
-       No checkpoint found. Starting new workflow.
-
-       Phase 0: Inputs Gate
-       ✓ ./tasks/prd-user-authentication/prd.md exists
-       ✗ ./tasks/prd-user-authentication/techspec.md missing
-       ✓ ./tasks/prd-user-authentication/tasks.md exists
-
-       Generating only missing file: Tech Spec...
-       Invoking /generate-spec prd-user-authentication...
-       [Command executes, generates techspec.md]
-
-       ✓ All inputs validated.
-
-       Phase 1: Analysis & Planning
-       Reading PRD, Tech Spec, and Tasks...
-       [Creates analysis.md and plan.md]
-       Checkpoint saved.
-       ...
-```
-
-### Scenario 2: All Files Exist
-```
-User: /feature-marker prd-payment-integration
-
-Agent: Checking for existing checkpoint...
-       No checkpoint found. Starting new workflow.
-
-       Phase 0: Inputs Gate
-       ✓ ./tasks/prd-payment-integration/prd.md exists
-       ✓ ./tasks/prd-payment-integration/techspec.md exists
-       ✓ ./tasks/prd-payment-integration/tasks.md exists
-
-       ✓ All inputs validated. Skipping generation.
-
-       Phase 1: Analysis & Planning
-       Reading existing PRD, Tech Spec, and Tasks...
-       [Creates analysis.md and plan.md]
-       Checkpoint saved.
-       ...
-```
-
-### Scenario 3: Resume from Checkpoint
-```
-User: /feature-marker prd-user-authentication
-
-Agent: Checkpoint found!
-       Phase 2 in progress (Task 2/6)
-       Last updated: 2026-01-19T10:30:00Z
-
-       Resume from checkpoint? [Y/n]
-
-User: Y
-
-Agent: Resuming from Task 2/6...
-       [Continues implementation]
-       ...
-       Phase 4: Commit & PR
-       Detected platform: GitHub
-       Creating PR via /checking-pr...
-
-       ✓ Feature complete!
-       PR URL: https://github.com/user/repo/pull/42
 ```

--- a/feature-marker-dist/feature-marker/SKILL.md
+++ b/feature-marker-dist/feature-marker/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: feature-marker
 description: >
-  End-to-end feature development orchestrator that automates the full lifecycle
-  from requirements to pull request. Generates PRD, Tech Spec, and Task
-  breakdown artifacts, then executes a 4-phase workflow: Analysis →
-  Implementation → Tests → Commit & PR. Supports 5 execution modes: Full
-  Workflow (generate all artifacts + run all phases), Tasks Only (skip
-  generation, use existing files), Ralph Loop (autonomous self-correcting
-  execution), Spec-Driven (multi-agent review with worktree isolation), and
-  Test Only (run tests phase exclusively). Includes checkpoint/resume so work
-  can be paused and resumed at any phase, and auto-detects GitHub, Azure DevOps,
-  or GitLab for PR creation. Platform-agnostic with auto stack detection for
-  iOS/Swift, Node.js/TypeScript, Rust, Python, and Go.
+  End-to-end feature development orchestrator. Generates PRD, TechSpec, and Tasks,
+  then executes a 4-phase workflow: Plan → Implement → Test → PR. Supports
+  checkpoint/resume, context-aware entry, and auto-detects GitHub, Azure DevOps,
+  or GitLab for PR creation. Platform-agnostic: iOS/Swift, Node.js/TypeScript,
+  Rust, Python, Go.
 
   ALWAYS use this skill when the user says "implement this feature", "build
   feature X", "start a new feature", "create a PRD", "generate tech spec",
@@ -19,124 +13,79 @@ description: >
   from spec", "run the full workflow", "resume feature", "continue where I
   left off", asks to go from requirements to implementation, wants to automate
   feature development end-to-end, mentions PRD-to-PR pipelines, or says
-  "/feature-marker" — even if they just say "I need to build X" without
-  explicitly mentioning a workflow. Also trigger when the user mentions
-  "Ralph Loop", "spec-driven mode", "checkpoint", or asks to generate tasks
-  from a PRD or tech spec.
+  "/feature-marker". Also trigger when the user mentions "spec-driven mode",
+  "checkpoint", or asks to generate tasks from a PRD or tech spec.
 tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite, Skill
 ---
 
 # feature-marker
 
-Automates feature development with a 5-phase workflow:
+Automates feature development with a 4-phase workflow:
 
-1. **Inputs Gate** - Validates `prd.md`, `techspec.md`, `tasks.md` exist; generates them via `~/.claude/commands/` if missing.
-2. **Analysis & Planning** - Auto-installs product-manager skill if missing; reads docs, creates implementation plan.
-3. **Implementation** - Executes tasks with progress tracking.
-4. **Tests & Validation** - Runs platform-appropriate test suites and build validation.
-   Auto-detects: Swift/Xcode (+ XcodeBuildMCP simulator), Node.js, Rust, Python, Go.
-5. **Commit & PR** - Auto-installs enhanced commit command if missing; commits changes using professional workflow and creates PR (auto-detects git platform).
+1. **Plan** — Validates/generates PRD, TechSpec, Tasks; creates implementation plan.
+2. **Implement** — Executes tasks with progress tracking and per-task checkpoints.
+3. **Test** — Runs platform-appropriate test suites and build validation.
+4. **PR** — Commits with the enhanced `/commit` command and creates a Pull Request.
 
 ## Platform Support
 
-feature-marker works with any tech stack:
-
-- 🍎 **iOS/Swift** — `swift test` + SwiftLint + XcodeBuildMCP simulator validation
-- 🟨 **Node.js/TypeScript** — auto-detects npm/yarn/pnpm/bun + Jest/Vitest
-- 🦀 **Rust** — `cargo test` + `cargo clippy`
-- 🐍 **Python** — `pytest` + ruff/flake8
-- 🐹 **Go** — `go test` + `go vet`
-
-iOS/Xcode projects get additional simulator validation via XcodeBuildMCP (optional, non-blocking).
-The platform is auto-detected once at workflow start and cached — no configuration required.
+| Stack     | Detection                             | Test              | Lint              |
+| --------- | ------------------------------------- | ----------------- | ----------------- |
+| iOS/Swift | `*.xcodeproj`, `Package.swift`        | `swift test`      | `swiftlint`       |
+| Node.js   | `package.json`                        | `jest` / `vitest` | `{pm} run lint`   |
+| Rust      | `Cargo.toml`                          | `cargo test`      | `cargo clippy`    |
+| Python    | `pyproject.toml` / `requirements.txt` | `pytest`          | `ruff` / `flake8` |
+| Go        | `go.mod`                              | `go test ./...`   | `go vet`          |
 
 ## Usage
 
 ```
 /feature-marker <feature-slug>
-```
-
-**Example**:
-
-```
-/feature-marker prd-user-authentication
-```
-
-### Interactive Mode
-
-```
 /feature-marker --interactive <feature-slug>
+/feature-marker --mode <mode> <feature-slug>
 ```
 
-Opens a menu to select execution mode:
+**Modes**: `full` (default) · `tasks-only` · `spec-driven` · `test-only`
 
-- **Full Workflow** - Default, generates missing files and executes all phases
-- **Tasks Only** - Uses existing files, skips generation phase
-- **Ralph Loop** - Autonomous continuous execution with ralph-wiggum
-- **Spec-Driven** - Multi-agent review + worktree isolation via spec-workflow
-- **Test Only** - Runs tests phase exclusively using platform-appropriate test guidance (Swift Testing for iOS, Jest/Vitest for Node.js, etc.)
+The skill detects project state on every invocation and suggests the right path:
 
-Works both in terminal (TTY menu) and Claude CLI (AskUserQuestion prompt).
-
-**Direct mode selection** (skip menu):
-
-```
-/feature-marker --mode full <feature-slug>
-/feature-marker --mode tasks-only <feature-slug>
-/feature-marker --mode ralph-loop <feature-slug>
-/feature-marker --mode spec-driven <feature-slug>
-/feature-marker --mode test-only <feature-slug>
-```
+- Checkpoint found → offers to resume
+- Tasks exist → suggests implement → test → pr
+- PRD/TechSpec exist → suggests generating missing files first
+- Nothing found → starts from PRD generation
 
 ## Prerequisites
 
-### Commands
+Commands in `~/.claude/commands/`:
 
-The following commands must be available in `~/.claude/commands/`:
+- `create-prd.md`
+- `generate-spec.md`
+- `generate-tasks.md`
 
-- `create-prd.md` - Creates a new PRD from requirements discussion
-- `generate-spec.md` - Generates technical specification from PRD
-- `generate-tasks.md` - Breaks down feature spec into implementable tasks
+Templates in `~/.claude/docs/specs/`:
 
-### Templates
+- `prd-template.md`
+- `techspec-template.md`
+- `tasks-template.md`
 
-The commands above read templates from `~/.claude/docs/specs/` to generate structured documents.
+## Project Structure
 
-Required templates:
-
-- `~/.claude/docs/specs/prd-template.md` - Product Requirements Document template
-- `~/.claude/docs/specs/techspec-template.md` - Technical Specification template
-- `~/.claude/docs/specs/tasks-template.md` - Tasks breakdown template
-
-**Template Format**: Templates should be markdown files with placeholders and structure that commands will use to generate feature-specific documents.
-
-**Setup**: Ensure these templates exist before running feature-marker:
-
-```bash
-ls ~/.claude/docs/specs/
-# Should show: prd-template.md, techspec-template.md, tasks-template.md
-```
-
-**Note**: If templates are missing, commands in `~/.claude/commands/` will fail to generate files.
-
-### Project Structure
-
-**Feature Documents** (generated in project):
+**Feature documents** (generated in project):
 
 ```
-./tasks/
-└── prd-{feature-name}/
-    ├── prd.md            ← Generated from ~/.claude/docs/specs/prd-template.md
-    ├── techspec.md       ← Generated from ~/.claude/docs/specs/techspec-template.md
-    ├── tasks.md          ← Generated from ~/.claude/docs/specs/tasks-template.md
-    └── {num}_task.md     ← Individual task files (optional)
+./tasks/{feature-slug}/
+├── prd.md
+├── techspec.md
+├── tasks.md
+└── {num}_task.md   (individual task files)
 ```
 
-**State Directory** (checkpoint & progress):
+**State directory** (checkpoint & progress):
 
 ```
-.claude/feature-state/{feature-name}/
+.claude/feature-state/{feature-slug}/
 ├── checkpoint.json
+├── platform-context.json
 ├── analysis.md
 ├── plan.md
 ├── progress.md
@@ -144,248 +93,35 @@ ls ~/.claude/docs/specs/
 └── pr-url.txt
 ```
 
-**User Configuration** (required setup):
-
-```
-~/.claude/
-├── commands/           ← Commands that generate files
-│   ├── create-prd.md
-│   ├── generate-spec.md
-│   └── generate-tasks.md
-└── docs/
-    └── specs/          ← Templates used by commands
-        ├── prd-template.md
-        ├── techspec-template.md
-        └── tasks-template.md
-```
-
-## Behavior
-
-When invoked, the skill:
-
-1. **Validates inputs** - Checks if `./tasks/prd-{feature-slug}/` contains required files
-   - If all files exist → Skips to step 3
-   - If any file is missing → Proceeds to step 2
-2. **Generates ONLY missing files** - Existing files are never overwritten:
-   - Missing PRD → `/create-prd`
-   - Missing Tech Spec → `/generate-spec {feature-slug}`
-   - Missing Tasks → `/generate-tasks {feature-slug}`
-3. **Auto-installs missing dependencies**:
-   - **Phase 1**: Checks for `product-manager` skill
-     - If missing: Installs via `npx skills add https://github.com/aj-geddes/claude-code-bmad-skills --skill product-manager`
-     - If user already has it: Uses user's version
-     - If installation fails: Continues without it (non-blocking)
-   - **Phase 4**: Checks for `/commit` command
-     - If missing: Copies from bundled `resources/commit.md` to `~/.claude/commands/commit.md`
-     - If user already has it: Uses user's version
-     - If installation fails: Falls back to standard commit workflow
-4. **Executes 5-phase workflow** via the `feature-marker` agent
-5. **Persists state** - Saves checkpoints after each phase/task for resume capability
-6. **Curates learning** - After Phase 4 (Commit & PR), if PR review comments or CI failure logs are available in the session, invoke the `learning-curator` sub-skill via `Skill` to summarize them into structured fix patterns for the learning store
-
-**Important**: The workflow is smart about file detection and dependencies:
-
-- ✅ Files/skills/commands exist → Uses them directly, no regeneration or reinstallation
-- ⚠️ Missing → Installs/generates only what's needed
-- 🔒 Never overwrites existing content
-- 👤 **User's versions always have priority** over bundled/auto-installed versions
-
 ## Auto-Installed Dependencies
 
-Feature-marker automatically installs missing dependencies to enhance the workflow:
+**product-manager skill** (Plan phase): advanced PRD analysis. Installed via `npx` if missing; non-blocking.
 
-### Product Manager Skill (Phase 1)
+**commit command** (PR phase): conventional commits with pre-commit validation. Copied from bundled `resources/commit.md` if missing; non-blocking.
 
-**What it does**: Provides advanced PRD analysis, requirements validation, and product management capabilities.
-
-**Installation**:
-
-- **Check**: Phase 1 checks for `~/.claude/skills/product-manager/SKILL.md`
-- **Install**: If missing and `npx` available, runs:
-  ```bash
-  npx skills add https://github.com/aj-geddes/claude-code-bmad-skills --skill product-manager
-  ```
-- **Priority**: Uses user's existing skill if already installed
-- **Fallback**: Continues without it if installation fails (non-blocking)
-
-**Benefits**:
-
-- Enhanced requirement analysis
-- Better PRD validation
-- Improved feature planning
-
-### Enhanced Commit Command (Phase 4)
-
-**What it does**: Professional commit workflow with validation, splitting, and conventional commit format.
-
-**Installation**:
-
-- **Check**: Phase 4 checks for `~/.claude/commands/commit.md`
-- **Install**: If missing, copies from bundled `resources/commit.md` to `~/.claude/commands/commit.md`
-- **Priority**: Uses user's existing command if already installed
-- **Fallback**: Uses standard commit workflow if installation fails
-
-**Features**:
-
-- Pre-commit validation (lint, build, docs)
-- Intelligent commit splitting
-- Conventional commit format with emojis
-- Smart file staging
-- No Co-Authored-By footer (as per command design)
-
-**Example Output**:
-
-```bash
-✨ feat: add user authentication system
-🐛 fix: resolve memory leak in rendering process
-📝 docs: update API documentation
-♻️ refactor: simplify error handling logic
-```
-
-### Manual Installation
-
-If auto-installation fails, you can install manually:
-
-**Product Manager Skill**:
-
-```bash
-npx skills add https://github.com/aj-geddes/claude-code-bmad-skills --skill product-manager
-```
-
-**Commit Command**:
-
-```bash
-cp ~/.claude/skills/feature-marker/resources/commit.md ~/.claude/commands/commit.md
-```
-
-## Template Setup Guide
-
-### Template Directory Structure
-
-Commands in `~/.claude/commands/` read templates from a centralized location:
-
-```
-~/.claude/docs/specs/
-├── prd-template.md          # Product Requirements Document template
-├── techspec-template.md     # Technical Specification template
-└── tasks-template.md        # Task breakdown template
-```
-
-### Why Templates in ~/.claude/docs/specs?
-
-- **Centralized**: All projects share the same templates
-- **User-controlled**: Users can customize their own templates
-- **Portable**: Commands reference templates via standard path
-- **Separation**: Templates are not in project repositories
-
-### Template Content
-
-Each template should be a markdown file with:
-
-- Clear section structure
-- Placeholder text or variables
-- Examples and formatting guidelines
-
-Commands read these templates and populate them with feature-specific content.
-
-### Setup Verification
-
-To verify your setup is complete:
-
-```bash
-# Check templates exist
-ls -l ~/.claude/docs/specs/
-
-# Check commands exist
-ls -l ~/.claude/commands/
-
-# Test feature-marker
-/feature-marker --interactive prd-test-feature
-```
-
-If templates are missing, create them in `~/.claude/docs/specs/` before running feature-marker.
-
-## Orchestrator Integration
-
-When invoked by the orchestrator, feature-marker reads these env vars:
-
-- `ORCHESTRATOR_MODE=true` — Enables machine-readable output
-- `FEATURE_ID=feat-001` — Which ID to tag outputs and PR titles
-- `CONTEXT_FILE=path/to/context.md` — Path to orchestrator context file (cross-feature context)
-- `RESULTS_FILE=path/to/results.json` — Where to write structured completion results
-
-### Completion Protocol
-
-On completion, feature-marker writes `$RESULTS_FILE`:
-
-```json
-{
-  "feature_id": "feat-001",
-  "status": "completed",
-  "pr_url": "https://github.com/user/repo/pull/42",
-  "commits": 3,
-  "tests_passed": true,
-  "artifacts": ["prd.md", "techspec.md", "tasks.md"],
-  "duration_seconds": 120,
-  "error": null
-}
-```
-
-All output filenames are determined by env vars set by the orchestrator. When `ORCHESTRATOR_MODE` is not set, feature-marker behaves normally with interactive output.
-
-### Context Injection
-
-When `CONTEXT_FILE` is set, feature-marker reads the file at startup and uses its contents as additional context during PRD generation and implementation planning. This enables cross-feature awareness — later features benefit from decisions made in earlier ones.
-
-## Plan Mode Integration
-
-When the user has used Claude's built-in plan mode before invoking feature-marker, the agent automatically:
-
-1. **Detects the most recent plan** from `~/.claude/plans/` (sorted by modification time)
-2. **Reads project conventions** from `./CLAUDE.md` at the project root (if present)
-3. **Uses both as rich context** to enhance PRD generation and reduce redundant clarification questions
-
-This is automatic and requires no additional flags or options. If no plan or CLAUDE.md exists, the workflow proceeds normally.
-
-**Recommended flow**:
-
-```
-1. Use Claude plan mode to explore the codebase and think through the feature
-2. Exit plan mode
-3. Run /feature-marker --interactive <feature-slug>
-4. Select "Full Workflow"
-5. The plan content automatically enriches PRD generation
-```
+**spec-workflow skills** (spec-driven mode only): lazy-installed from bundled resources on first use.
 
 ## Checkpoint & Resume
 
-If interrupted (Ctrl+C, session crash, etc.), re-invoke with the same feature slug to resume:
+If interrupted, re-invoke with the same feature slug:
 
 ```
 /feature-marker prd-user-authentication
 ```
 
-The skill will:
+The skill detects the checkpoint and offers to resume from the saved phase and task index.
 
-- Detect existing checkpoint
-- Show current progress (phase, task index)
-- Ask if you want to resume or start fresh
+## Platform Detection (PR)
 
-## Platform Detection
-
-In Phase 4, the skill auto-detects your git platform and selects the appropriate PR skill:
-
-| Platform     | Detection                     | PR Skill      |
-| ------------ | ----------------------------- | ------------- |
-| GitHub       | `github.com` in remote URL    | `checking-pr` |
-| Azure DevOps | `dev.azure.com` in remote URL | `azure-pr`    |
-| GitLab       | `gitlab.com` in remote URL    | `checking-pr` |
-| Bitbucket    | `bitbucket.org` in remote URL | `checking-pr` |
-| Other        | (fallback)                    | `checking-pr` |
+| Remote URL                             | PR Skill      |
+| -------------------------------------- | ------------- |
+| `github.com`                           | `checking-pr` |
+| `dev.azure.com`                        | `azure-pr`    |
+| `gitlab.com` / `bitbucket.org` / other | `checking-pr` |
 
 ## Configuration
 
-Override default behavior with `.feature-marker.json` in your repository root:
+Override defaults with `.feature-marker.json` at the repo root:
 
 ```json
 {
@@ -399,122 +135,11 @@ Override default behavior with `.feature-marker.json` in your repository root:
 
 ## Error Handling
 
-| Scenario             | Behavior                              |
-| -------------------- | ------------------------------------- |
-| Missing files        | Auto-generate via commands            |
-| No git repo          | Fail early with helpful message       |
-| No tests             | Skip Phase 3 with warning             |
-| Test failures        | Report issues, allow fix, offer retry |
-| Unknown platform     | Fallback to `checking-pr`             |
-| PR skill unavailable | Commit only, log manual instructions  |
-
-## Example Sessions
-
-### Example 1: All Files Exist (No Generation Needed)
-
-```
-> /feature-marker prd-user-authentication
-
-Checking for existing checkpoint...
-No checkpoint found. Starting new workflow.
-
-Phase 0: Inputs Gate
-✓ prd.md exists
-✓ techspec.md exists
-✓ tasks.md exists
-✅ All files present. Skipping generation.
-
-Phase 1: Analysis & Planning
-Reading existing documents...
-Creating implementation plan...
-Checkpoint saved.
-
-Phase 2: Implementation
-[1/6] Create User entity... ✓
-[2/6] Add authentication service... ✓
-...
-```
-
-### Example 2: Partial Files (Generates Only Missing)
-
-```
-> /feature-marker prd-payment-integration
-
-Checking for existing checkpoint...
-No checkpoint found. Starting new workflow.
-
-Phase 0: Inputs Gate
-✓ prd.md exists
-✗ techspec.md missing → Generating via /generate-spec...
-✓ tasks.md exists
-
-✅ Generated missing file. All inputs ready.
-
-Phase 1: Analysis & Planning
-Reading documents...
-Creating implementation plan...
-Checkpoint saved.
-...
-```
-
-### Example 3: Complete Workflow with Auto-Install
-
-```
-> /feature-marker prd-new-feature
-
-Phase 0: Inputs Gate
-✗ prd.md missing → Generating via /create-prd...
-✗ techspec.md missing → Generating via /generate-spec...
-✗ tasks.md missing → Generating via /generate-tasks...
-
-Phase 1: Analysis & Planning
-⚙️  Installing product-manager skill...
-✓ product-manager skill installed successfully
-Reading PRD, Tech Spec, and Tasks...
-Creating implementation plan...
-Checkpoint saved.
-
-Phase 2: Implementation
-[1/6] Create User entity... ✓
-[2/6] Add authentication service... ✓
-[3/6] Implement login endpoint... ✓
-[4/6] Add JWT token handling... ✓
-[5/6] Create logout endpoint... ✓
-[6/6] Add session management... ✓
-Checkpoint saved.
-
-Phase 3: Tests & Validation
-✅ Platform detected: Node.js / Next.js (pnpm)
-Running: jest --findRelatedTests src/api/users.ts
-✅ 14 passed, 0 failed
-Lint: pnpm run lint ✅
-Checkpoint saved.
-
-Phase 4: Commit & PR
-⚙️  Installing commit command...
-✓ commit command installed successfully
-Using enhanced commit workflow (/commit)...
-✨ feat: implement user authentication system
-Detected platform: GitHub
-Creating PR via /checking-pr...
-
-✓ Feature complete!
-PR URL: https://github.com/user/repo/pull/42
-```
-
-### Example 4: Using Existing User Tools
-
-```
-> /feature-marker prd-payment-feature
-
-Phase 0: Inputs Gate
-✓ All inputs validated.
-
-Phase 1: Analysis & Planning
-✓ product-manager skill already installed (using user's version)
-...
-
-Phase 4: Commit & PR
-✓ commit command already exists (using user's version)
-...
-```
+| Scenario             | Behavior                             |
+| -------------------- | ------------------------------------ |
+| Missing files        | Auto-generate via commands           |
+| No git repo          | Fail early with message              |
+| No tests             | Skip Test phase with warning         |
+| Test failures        | Report, allow fix, offer retry       |
+| Unknown platform     | Fall back to `checking-pr`           |
+| PR skill unavailable | Commit only; log manual instructions |

--- a/feature-marker-dist/feature-marker/feature-marker.sh
+++ b/feature-marker-dist/feature-marker/feature-marker.sh
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     --version|-V)
-      echo "feature-marker v5.2.0"
+      echo "feature-marker v7.0.0"
       exit 0
       ;;
     --interactive|-i)
@@ -247,7 +247,7 @@ if [[ "${INTERACTIVE_MODE}" == "true" ]]; then
     echo "  The agent will execute all 4 phases with file generation"
     echo ""
   fi
-else
+elif [[ -z "${EXECUTION_MODE:-}" ]]; then
   info "To start/continue this workflow, use Claude Code:"
   echo "  /feature-marker ${FEATURE_NAME}"
   echo "  /feature-marker --interactive ${FEATURE_NAME}  # For interactive mode"

--- a/feature-marker-dist/feature-marker/lib/config.sh
+++ b/feature-marker-dist/feature-marker/lib/config.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 # Default paths (can be overridden via .feature-marker.json)
 DOCS_PATH="./tasks"
 STATE_PATH=".claude/feature-state"
+SKILLS_DIR="${HOME}/.claude/skills"
+COMMANDS_DIR="${HOME}/.claude/commands"
 
 # Load project-specific configuration if exists
 load_config() {
@@ -28,7 +30,7 @@ validate_git_repo() {
 # Validate required directories exist
 validate_directories() {
   local feature_name="$1"
-  local feature_path="${DOCS_PATH}/prd-${feature_name}"
+  local feature_path="${DOCS_PATH}/${feature_name}"
 
   if [[ ! -d "${DOCS_PATH}" ]]; then
     echo "Creating ${DOCS_PATH} directory..."
@@ -47,7 +49,7 @@ validate_directories() {
 # Check if feature files exist
 check_feature_files() {
   local feature_name="$1"
-  local feature_path="${DOCS_PATH}/prd-${feature_name}"
+  local feature_path="${DOCS_PATH}/${feature_name}"
   local status=0
 
   echo "Checking feature files in ${feature_path}..."
@@ -79,7 +81,7 @@ check_feature_files() {
 # Get the path to a feature's docs directory
 get_feature_path() {
   local feature_name="$1"
-  echo "${DOCS_PATH}/prd-${feature_name}"
+  echo "${DOCS_PATH}/${feature_name}"
 }
 
 # Get the path to a feature's state directory

--- a/feature-marker-dist/feature-marker/lib/dependency-installer.sh
+++ b/feature-marker-dist/feature-marker/lib/dependency-installer.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Check if product-manager skill exists, install if missing
 ensure_product_manager_skill() {
-  local skill_path="${HOME}/.claude/skills/product-manager/SKILL.md"
+  local skill_path="${SKILLS_DIR:-${HOME}/.claude/skills}/product-manager/SKILL.md"
 
   if [[ -f "${skill_path}" ]]; then
     echo "✓ product-manager skill already installed"
@@ -34,12 +34,12 @@ ensure_product_manager_skill() {
 
 # Check if commit command exists, install if missing
 ensure_commit_command() {
-  local user_commit_path="${HOME}/.claude/commands/commit.md"
+  local user_commit_path="${COMMANDS_DIR:-${HOME}/.claude/commands}/commit.md"
   local bundled_commit_path
 
   # Try to find bundled commit.md in feature-marker installation
-  if [[ -f "${HOME}/.claude/skills/feature-marker/resources/commit.md" ]]; then
-    bundled_commit_path="${HOME}/.claude/skills/feature-marker/resources/commit.md"
+  if [[ -f "${SKILLS_DIR:-${HOME}/.claude/skills}/feature-marker/resources/commit.md" ]]; then
+    bundled_commit_path="${SKILLS_DIR:-${HOME}/.claude/skills}/feature-marker/resources/commit.md"
   elif [[ -n "${FEATURE_MARKER_ROOT:-}" ]] && [[ -f "${FEATURE_MARKER_ROOT}/resources/commit.md" ]]; then
     bundled_commit_path="${FEATURE_MARKER_ROOT}/resources/commit.md"
   else
@@ -74,7 +74,7 @@ ensure_commit_command() {
 
 # Check if spec-workflow skills exist
 check_spec_workflow_skills() {
-  local skills_dir="${HOME}/.claude/skills"
+  local skills_dir="${SKILLS_DIR:-${HOME}/.claude/skills}"
   local required_skills=("spec-orchestrator" "spec-executor")
 
   for skill in "${required_skills[@]}"; do
@@ -91,8 +91,8 @@ get_bundled_spec_workflow_path() {
   local bundled_path=""
 
   # Priority 1: Installed feature-marker skill location
-  if [[ -d "${HOME}/.claude/skills/feature-marker/resources/spec-workflow/skills" ]]; then
-    bundled_path="${HOME}/.claude/skills/feature-marker/resources/spec-workflow/skills"
+  if [[ -d "${SKILLS_DIR:-${HOME}/.claude/skills}/feature-marker/resources/spec-workflow/skills" ]]; then
+    bundled_path="${SKILLS_DIR:-${HOME}/.claude/skills}/feature-marker/resources/spec-workflow/skills"
   # Priority 2: FEATURE_MARKER_ROOT environment variable
   elif [[ -n "${FEATURE_MARKER_ROOT:-}" ]] && [[ -d "${FEATURE_MARKER_ROOT}/resources/spec-workflow/skills" ]]; then
     bundled_path="${FEATURE_MARKER_ROOT}/resources/spec-workflow/skills"
@@ -110,7 +110,7 @@ get_bundled_spec_workflow_path() {
 
 # Install spec-workflow skills from bundled resources
 ensure_spec_workflow_skills() {
-  local target_dir="${HOME}/.claude/skills"
+  local target_dir="${SKILLS_DIR:-${HOME}/.claude/skills}"
   local skills=("idea-explorer" "spec-writer" "spec-orchestrator" "spec-executor" "create-worktree" "spec-workflow-init")
   local installed=0
 

--- a/feature-marker-dist/feature-marker/lib/menu.sh
+++ b/feature-marker-dist/feature-marker/lib/menu.sh
@@ -88,7 +88,7 @@ confirm_mode() {
 # Check if files exist for tasks-only mode
 validate_tasks_only_mode() {
   local feature_name="$1"
-  local feature_path="${DOCS_PATH}/prd-${feature_name}"
+  local feature_path="${DOCS_PATH}/${feature_name}"
 
   local missing=()
 
@@ -118,7 +118,7 @@ check_ralph_available() {
   fi
 
   # Check if skill exists
-  if [[ -f "${HOME}/.claude/skills/ralph-wiggum/ralph-wiggum.sh" ]]; then
+  if [[ -f "${SKILLS_DIR:-${HOME}/.claude/skills}/ralph-wiggum/ralph-wiggum.sh" ]]; then
     return 0
   fi
 
@@ -141,9 +141,8 @@ show_ralph_install_instructions() {
 
 # Check if spec-workflow skills are available
 check_spec_workflow_available() {
-  local skills_dir="${HOME}/.claude/skills"
+  local skills_dir="${SKILLS_DIR:-${HOME}/.claude/skills}"
 
-  # Check for core spec-workflow skills
   if [[ -f "${skills_dir}/spec-orchestrator/SKILL.md" ]] && \
      [[ -f "${skills_dir}/spec-executor/SKILL.md" ]]; then
     return 0
@@ -157,8 +156,8 @@ get_bundled_spec_workflow_path() {
   local bundled_path=""
 
   # Priority 1: Installed feature-marker skill location
-  if [[ -d "${HOME}/.claude/skills/feature-marker/resources/spec-workflow/skills" ]]; then
-    bundled_path="${HOME}/.claude/skills/feature-marker/resources/spec-workflow/skills"
+  if [[ -d "${SKILLS_DIR:-${HOME}/.claude/skills}/feature-marker/resources/spec-workflow/skills" ]]; then
+    bundled_path="${SKILLS_DIR:-${HOME}/.claude/skills}/feature-marker/resources/spec-workflow/skills"
   # Priority 2: FEATURE_MARKER_ROOT environment variable
   elif [[ -n "${FEATURE_MARKER_ROOT:-}" ]] && [[ -d "${FEATURE_MARKER_ROOT}/resources/spec-workflow/skills" ]]; then
     bundled_path="${FEATURE_MARKER_ROOT}/resources/spec-workflow/skills"
@@ -176,7 +175,7 @@ get_bundled_spec_workflow_path() {
 
 # Install spec-workflow skills from bundled resources
 install_spec_workflow_skills() {
-  local target_dir="${HOME}/.claude/skills"
+  local target_dir="${SKILLS_DIR:-${HOME}/.claude/skills}"
   local skills=("idea-explorer" "spec-writer" "spec-orchestrator" "spec-executor" "create-worktree" "spec-workflow-init")
 
   # Get bundled path

--- a/feature-marker-dist/feature-marker/lib/state-manager.sh
+++ b/feature-marker-dist/feature-marker/lib/state-manager.sh
@@ -18,19 +18,19 @@ init_feature_state() {
   if [[ ! -f "$checkpoint" ]]; then
     cat > "$checkpoint" << EOF
 {
-  "version": "1.2.0",
+  "version": "7.0.0",
   "feature_name": "${feature_name}",
   "project_path": "$(pwd)",
-  "current_phase": 0,
+  "current_phase": "plan",
   "phase_status": "pending",
+  "spec_driven": false,
   "phases": {
-    "1": {"name": "Analysis & Planning", "status": "pending"},
-    "2": {"name": "Implementation", "status": "pending"},
-    "3": {"name": "Tests & Validation", "status": "pending"},
-    "4": {"name": "Commit & PR", "status": "pending"}
+    "plan":      {"status": "pending"},
+    "implement": {"status": "pending"},
+    "test":      {"status": "pending"},
+    "pr":        {"status": "pending"}
   },
   "last_updated": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-  "paused": false,
   "error_state": null
 }
 EOF
@@ -63,9 +63,9 @@ get_current_phase() {
   local checkpoint="${STATE_PATH}/${feature_name}/checkpoint.json"
 
   if [[ -f "$checkpoint" ]]; then
-    jq -r '.current_phase // 0' "$checkpoint"
+    jq -r '.current_phase // "plan"' "$checkpoint"
   else
-    echo "0"
+    echo "plan"
   fi
 }
 
@@ -81,7 +81,7 @@ get_phase_status() {
   fi
 }
 
-# Update phase in checkpoint
+# Update phase in checkpoint (phase is one of: plan, implement, test, pr)
 update_phase() {
   local feature_name="$1"
   local phase="$2"
@@ -91,7 +91,7 @@ update_phase() {
   if [[ -f "$checkpoint" ]]; then
     local tmp=$(mktemp)
     jq --arg phase "$phase" --arg status "$status" --arg now "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" '
-      .current_phase = ($phase | tonumber) |
+      .current_phase = $phase |
       .phase_status = $status |
       .phases[$phase].status = $status |
       .last_updated = $now
@@ -134,14 +134,14 @@ save_error_state() {
   fi
 }
 
-# Check if workflow is paused
-is_paused() {
+# Check if workflow has an error state
+has_error_state() {
   local feature_name="$1"
   local checkpoint="${STATE_PATH}/${feature_name}/checkpoint.json"
 
   if [[ -f "$checkpoint" ]]; then
-    local paused=$(jq -r '.paused // false' "$checkpoint")
-    [[ "$paused" == "true" ]]
+    local error=$(jq -r '.error_state // empty' "$checkpoint")
+    [[ -n "$error" ]]
   else
     return 1
   fi

--- a/feature-marker-dist/feature-marker/lib/ui.sh
+++ b/feature-marker-dist/feature-marker/lib/ui.sh
@@ -142,7 +142,7 @@ separator() {
 banner() {
   echo ""
   echo -e "${BOLD}╔═══════════════════════════════════════╗${NC}"
-  echo -e "${BOLD}║        feature-marker v1.2.0          ║${NC}"
+  echo -e "${BOLD}║        feature-marker v7.0.0          ║${NC}"
   echo -e "${BOLD}╚═══════════════════════════════════════╝${NC}"
   echo ""
 }


### PR DESCRIPTION
## Summary

- 978 lines removed across SKILL.md (521->145) and agents/feature-marker.md (901->296)
- Strips example sessions, orchestrator machinery, hardcoded model name from agent frontmatter
- Replaces tool-name references with intent-based language throughout
- Adds SKILLS_DIR / COMMANDS_DIR to config.sh; removes all hardcoded ~/.claude/ paths
- Redesigns checkpoint schema for v7: phases plan/implement/test/pr; drops paused/orchestrator fields; adds spec_driven flag
- Fixes double prd- prefix bug in config.sh and menu.sh
- Fixes misleading message that fired during --mode invocations mid-execution
- Fixes interactive flow: agent tracks mode from its own response, not EXECUTION_MODE env var
- Aligns version to 7.0.0 across ui.sh banner and --version flag

## Part of v7 two-PR plan

- PR-1 (this): trim + decouple + bug fixes
- PR-2 (next): 4 phase sub-agents + context-aware entry point + lazy spec-workflow loading

## Test plan

- [ ] feature-marker.sh --version outputs v7.0.0
- [ ] --interactive with no TTY outputs INTERACTIVE_MODE_REQUESTED and exits 100
- [ ] --mode full does NOT print to-start/continue message
- [ ] ./tasks/prd-user-auth/ created without double prd- prefix
- [ ] New checkpoint.json uses plan/implement/test/pr phase keys and version 7.0.0
- [ ] SKILLS_DIR override respected by menu.sh and dependency-installer.sh
