### PR TITLE
docs(v7): remove orchestrator references, update skill modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 <p align="center">
-  <strong>AI-powered feature development skill for Claude Code.<br>PRD → Tech Spec → Tasks → Implementation → Tests → PR — automated, with checkpoint/resume and autonomous multi-feature orchestration.</strong>
+  <strong>AI-powered feature development skill for Claude Code.<br>PRD → Tech Spec → Tasks → Implementation → Tests → PR — automated, with checkpoint/resume across multiple execution modes.</strong>
 </p>
 
 <p align="center">
@@ -67,11 +67,7 @@ Building a feature end-to-end means context-switching between planning, coding, 
 
 ## How It Works
 
-Two entry points, one pipeline. Run it **inside Claude Code** for a single feature, or use the **terminal orchestrator** to process a full backlog. → [Full walkthrough](assets/HOW_IT_WORKS.md)
-
-<p align="center">
-  <img src="assets/img_two_paths.png" alt="Two paths: in-Claude skill vs terminal orchestrator" width="700">
-</p>
+Invoke the skill once — feature-marker reads your project state and presents a single confirmation prompt, then runs the pipeline. → [Full walkthrough](assets/HOW_IT_WORKS.md)
 
 ```
 /feature-marker my-feature
@@ -94,8 +90,7 @@ Each phase writes a checkpoint. Re-run with the same name to resume exactly wher
 - **Checkpoint / resume** — pause at any phase, pick up later with the same command
 - **Per-task validation** — lint + related tests after each task; auto-fix on failure
 - **Stack detection** — auto-detects iOS, Node.js, Rust, Python, Go for correct test and lint commands
-- **Multi-feature orchestrator** — reads a backlog (Markdown, GitHub, Linear, Jira), creates isolated worktrees, processes features autonomously
-- **Cross-feature context** — decisions and error patterns from previous features inform the next one
+- **Multiple execution modes** — Full, Tasks-Only, Spec-Driven, Test-Only
 - **Safety guardrails** — breaking change detection, schema migration review, configurable file-change limits
 - **Custom review personas** — domain-specific agents for Firebase, iOS, API Security, Payments, and Migrations
 
@@ -107,7 +102,7 @@ Each phase writes a checkpoint. Re-run with the same name to resume exactly wher
 # Recommended
 npx skills add Viniciuscarvalho/Feature-marker
 
-# Homebrew (includes orchestrator CLI)
+# Homebrew
 brew tap viniciuscarvalho/tap && brew install feature-marker
 
 # NPX
@@ -117,8 +112,6 @@ npx @viniciuscarvalho/feature-marker install
 git clone https://github.com/Viniciuscarvalho/Feature-marker.git
 cd Feature-marker && ./feature-marker-dist/feature-marker/install.sh
 ```
-
-The orchestrator CLI requires the Claude Code CLI (`claude --version`) and a platform CLI (`gh`, `glab`, or `az`) for PR creation.
 
 ---
 

--- a/assets/HOW_IT_WORKS.md
+++ b/assets/HOW_IT_WORKS.md
@@ -1,28 +1,25 @@
 # How Feature-marker Works
 
-Feature-marker has two distinct ways to use it. Both use the same pipeline intelligence — the difference is **who controls the loop**.
-
-![Two paths: Skill vs Orchestrator](./img_two_paths.png)
+Feature-marker is a Claude Code skill that automates the full feature development lifecycle inside a single Claude session. Invoke it once — it reads your project state and runs the pipeline.
 
 ---
 
-## Path 1: The Skill (inside Claude Code)
-
-You invoke Feature-marker directly in Claude Code. Claude runs the full pipeline in a single interactive session. This is the simplest way to use it — one feature, one command.
+## The Skill (inside Claude Code)
 
 ```bash
-# Standard mode — runs all phases automatically
 /feature-marker prd-user-authentication
-
-# Interactive mode — pauses after each phase for your approval
-/feature-marker --interactive prd-user-authentication
 ```
+
+feature-marker reads your project state on every invocation and presents a single confirmation:
+
+- Checkpoint found → offers to resume from saved phase
+- Tasks exist → suggests implement → test → pr
+- PRD/TechSpec exist → suggests generating missing files first
+- Nothing found → starts from PRD generation
 
 ### The pipeline
 
 Every feature goes through 4 phases. Each phase produces artifacts that feed the next.
-
-![Skill pipeline phases](./img_pipeline.png)
 
 ### Phase 1 — Analysis
 
@@ -35,7 +32,7 @@ Feature-marker reads your prompt, scans your codebase, and generates three docum
 Output location:
 
 ```
-tasks/prd-{feature-name}/
+tasks/{feature-name}/
 ├── prd.md
 ├── techspec.md
 └── tasks.md
@@ -45,36 +42,22 @@ tasks/prd-{feature-name}/
 
 Feature-marker executes each task from `tasks.md`. It writes code following your project's patterns — the same naming conventions, file structure, error handling, and config management it detected in Phase 1.
 
-If the project has specialized agents in `.claude/agents/` (like a Swift agent or a SwiftUI agent), the orchestrator can route specific tasks to them. In standalone skill mode, Feature-marker handles everything itself.
-
 ### Phase 3 — Testing
 
-Tests are written using your project's test framework (detected automatically — Swift Testing, XCTest, Jest, pytest, etc.). Feature-marker runs the tests, and if any fail, it enters the Ralph Loop: fix the failure, re-run, repeat until green.
+Tests are written using your project's test framework (detected automatically — Swift Testing, XCTest, Jest, pytest, etc.). Feature-marker runs the tests, and if any fail, it attempts to fix and re-run.
 
 ### Phase 4 — Delivery
 
 Feature-marker commits the changes, pushes the branch, and creates a Pull Request. It auto-detects your platform (GitHub, GitLab, Azure DevOps) and uses the appropriate CLI.
 
-### Interactive mode
-
-When you use `--interactive`, Feature-marker pauses after each phase and shows you the output. You can:
-
-- **Approve** — continue to the next phase
-- **Request changes** — ask Claude to modify the output before continuing
-- **Skip** — move to the next phase without changes
-
-This gives you full control over the process while still automating the heavy lifting.
-
 ### Execution modes
 
-| Mode          | Command                                  | Description                                 |
-| ------------- | ---------------------------------------- | ------------------------------------------- |
-| Full workflow | `/feature-marker prd-auth`               | All 4 phases, start to finish               |
-| Interactive   | `/feature-marker --interactive prd-auth` | Pause after each phase for approval         |
-| Tasks only    | `/feature-marker --tasks-only prd-auth`  | Skip PRD/TechSpec, use existing spec files  |
-| Ralph Loop    | `/feature-marker --ralph prd-auth`       | Autonomous: implement → test → fix → repeat |
-| Spec-driven   | `/feature-marker --spec-driven prd-auth` | Multi-agent review with worktree isolation  |
-| Test only     | `/swift-testing`                         | Run just the testing phase                  |
+| Mode        | Command                                       | Description                                |
+| ----------- | --------------------------------------------- | ------------------------------------------ |
+| Full        | `/feature-marker prd-auth`                    | All 4 phases, start to finish              |
+| Tasks only  | `/feature-marker --mode tasks-only prd-auth`  | Skip PRD/TechSpec, use existing spec files |
+| Spec-driven | `/feature-marker --mode spec-driven prd-auth` | Multi-agent review with worktree isolation |
+| Test only   | `/feature-marker --mode test-only prd-auth`   | Run just the testing phase                 |
 
 ### Checkpoint and resume
 
@@ -82,269 +65,24 @@ You can pause at any time. Feature-marker saves its state to `checkpoint.json`. 
 
 ```
 .claude/feature-state/{feature-name}/
-├── checkpoint.json    # Current phase + task progress
-├── analysis.md        # Phase 1 output summary
-├── plan.md            # Execution plan
-├── progress.md        # Task completion tracking
-└── test-results.md    # Phase 3 results
+├── checkpoint.json       # Current phase + task progress
+├── platform-context.json # Detected stack and tooling
+├── analysis.md           # Phase 1 output summary
+├── plan.md               # Execution plan
+├── progress.md           # Task completion tracking
+└── test-results.md       # Phase 3 results
 ```
-
----
-
-## Path 2: The Orchestrator (terminal)
-
-The orchestrator is a bash script that runs **outside** Claude Code, in your regular terminal. It reads a backlog, creates isolated git worktrees, and invokes Feature-marker once per feature in a loop. You run one command and walk away — it creates PRs for each feature.
-
-```bash
-# First time: scaffold config files
-feature-marker-orchestrate init
-
-# Run the orchestration loop
-feature-marker-orchestrate run
-```
-
-![Orchestrator architecture](./img_orchestrator.png)
-
-### How it works step by step
-
-The orchestrator is a `for` loop in bash. For each feature in the backlog, it calls `claude --agent feature-marker` to run the pipeline. When Claude finishes, control returns to bash — it collects results and updates memory. Once all features finish, the loop creates PRs and cleans up worktrees in a single pass.
-
-![Terminal execution flow](./orchestrator-terminal-flow.png)
-
-### Setting up
-
-**1. Initialize** — creates config files in your project:
-
-```bash
-feature-marker-orchestrate init
-# Creates:
-#   .orchestrator/config.yaml   — settings (committed to git)
-#   .env.example                — API key template (committed)
-#   .gitignore entries          — protects secrets and state
-```
-
-**2. Configure your backlog source** — edit `.orchestrator/config.yaml`:
-
-```yaml
-source:
-  type: linear # linear | github | jira | markdown
-  linear:
-    team: ENG
-    label: feature-marker
-```
-
-**3. Add your API keys** — copy the template and fill in your keys:
-
-```bash
-cp .env.example .env
-# Edit .env with your keys (never committed)
-```
-
-**4. Define your backlog** — depends on source type:
-
-For `markdown` (simplest, no API needed):
-
-```markdown
-# features.md
-
-## [HIGH] feat-001: Add OAuth2 login with Google
-
-Implement Google OAuth2 login flow with token refresh.
-labels: auth, backend
-
-## [MEDIUM] feat-002: Webhook retry with backoff
-
-Add retry logic to the webhook dispatcher.
-Depends on: none
-
-## [LOW] feat-003: Dark mode toggle
-
-Add dark mode toggle to settings page.
-```
-
-For `linear` or `github`, the orchestrator fetches issues automatically based on your config.
-
-**5. Preview** — see what would happen without executing:
-
-```bash
-feature-marker-orchestrate run --dry-run
-```
-
-**6. Run**:
-
-```bash
-feature-marker-orchestrate run
-```
-
-### Backlog sources
-
-The orchestrator supports multiple backlog sources. Each uses an **adapter** — a small script that calls the API and normalizes features into the same JSON format. The orchestrator itself never talks to Linear/GitHub directly.
-
-| Source            | Config           | What it needs                                |
-| ----------------- | ---------------- | -------------------------------------------- |
-| **Linear**        | `type: linear`   | `LINEAR_API_KEY` in `.env`                   |
-| **GitHub Issues** | `type: github`   | `gh` CLI authenticated                       |
-| **Jira**          | `type: jira`     | `JIRA_API_TOKEN` + `JIRA_BASE_URL` in `.env` |
-| **Markdown**      | `type: markdown` | A `features.md` file in your project         |
-
-All API keys live in `.env` (never committed). The `config.yaml` only has parameters (team name, label, JQL query) — safe to commit.
-
-### Autonomy levels
-
-| Level                    | What happens                                                             | Best for                            |
-| ------------------------ | ------------------------------------------------------------------------ | ----------------------------------- |
-| **Supervised**           | Full pipeline with `--interactive`; pauses after each phase for approval | New projects, critical features     |
-| **Checkpoint** (default) | Full pipeline, creates draft PR, waits for human review to merge         | Established projects                |
-| **Full auto**            | Full pipeline, creates PR, auto-merges when CI passes                    | Low-risk features, batch operations |
-
-Override per run:
-
-```bash
-feature-marker-orchestrate run --autonomy full_auto
-```
-
-**What `full_auto` actually does differently:**
-
-- Passes `--permission-mode bypassPermissions` to every Claude invocation so
-  file writes, bash commands, and network calls run without interactive prompts.
-  The orchestrator prints a warning banner before each feature.
-- Extends the Phase 3 Ralph Loop from 2 fix attempts to 5 (override via
-  `CFG_PHASE3_FULL_AUTO_MAX_FIX_ATTEMPTS`). Each fix attempt reads from and
-  writes to the 3-tier learning store, so repeated failures across features
-  converge on known-good fixes.
-- Use this only in sandboxed environments (isolated worktrees, disposable
-  CI runners) where unattended shell access is acceptable.
-
-### Memory between features
-
-The orchestrator keeps three layers of context that accumulate as features complete:
-
-**Context carry-forward** — After feat-001 finishes, the orchestrator records what files were created, what schema changed, what dependencies were added. When feat-002 starts, this context is injected into the Claude session _before_ generating the PRD. So feat-002's TechSpec can reference code from feat-001.
-
-**Error patterns** — When a feature fails, the error is logged with context. Subsequent features receive these patterns so they can proactively avoid the same issues.
-
-**Environment refresh** — Between features, the orchestrator can re-detect installed tools, new dependencies, and changed project structure.
-
-### Agent routing
-
-If your project has specialized agents in `.claude/agents/`, the orchestrator discovers them and delegates tasks to the most appropriate agent instead of using the generic Feature-marker skill for everything.
-
-For example, in a Swift/iOS project:
-
-```
-.claude/agents/
-├── swift-agent.md           # Swift implementation
-├── swiftui-agent.md         # SwiftUI views
-├── swift-testing-agent.md   # Swift Testing framework
-└── review-agent.md          # Code review
-```
-
-When a feature generates tasks, the orchestrator matches each task's tags to agent capabilities:
-
-- Implementation task tagged `swift` → `swift-agent`
-- UI task tagged `swiftui` → `swiftui-agent`
-- Testing task → `swift-testing-agent`
-- Review (always last) → `review-agent`
-
-If no agents are found, Feature-marker handles everything — the system degrades gracefully.
-
-### CLI reference
-
-**Subcommands:**
-
-```bash
-feature-marker-orchestrate run          # Execute the orchestration loop
-feature-marker-orchestrate init         # Scaffold config files
-feature-marker-orchestrate status       # Show current state
-feature-marker-orchestrate clean        # Remove worktrees + reset state
-```
-
-**Flags:**
-
-```bash
---autonomy <level>     # supervised | checkpoint | full_auto
-                       # checkpoint: stages worktrees + estimates cost, then halts at
-                       # awaiting-pipeline — Claude does not run until you resume manually
---adapter <type>       # linear | github | jira | markdown
---dry-run              # Show plan without executing (use with run)
---feature <id>         # Run only one feature
---resume-paused <id>   # Resume a paused feature from its checkpoint
---config <path>        # Use a different config file
-```
-
-**Per-run logs** are written to `.orchestrator/state/<feat-id>/logs/run-<timestamp>.log`.
-There is no verbose flag; pipe stdout+stderr to capture all output:
-
-```bash
-feature-marker-orchestrate run --feature feat-auth 2>&1 | tee debug.log
-```
-
----
-
-## How the two paths relate
-
-```
-┌─────────────────────────────────────────────────────┐
-│              Your terminal                           │
-│                                                      │
-│  feature-marker-orchestrate run                        │
-│     │                                                │
-│     ├─ reads config.yaml + .env                      │
-│     ├─ fetches backlog (Linear / GitHub / .md)       │
-│     ├─ for each feature:                             │
-│     │    ├─ git worktree add                         │
-│     │    ├─ claude --agent feature-marker            │ ← calls Claude Code
-│     │    │         prd-<feat-id>                     │
-│     │    │    └─ Feature-marker skill runs           │ ← same skill as Path 1
-│     │    │       PRD → TechSpec → Tasks → Code       │
-│     │    │       → Tests → PR → (returns to bash)    │
-│     │    │                                           │
-│     │    ├─ collect results                          │
-│     │    └─ update memory                            │
-│     │                                                │
-│     ├─ create PRs + cleanup worktrees (post-loop)    │
-│     └─ next feature (with accumulated context)       │
-│                                                      │
-└──────────────────────────────────────────────────────┘
-```
-
-The orchestrator calls the **same skill** that you invoke manually with `/feature-marker`. The difference is that the bash script controls the loop, worktrees, and memory — Claude only sees one feature at a time. This means the skill works identically whether you invoke it directly in Claude Code or the orchestrator calls it via `claude` CLI.
 
 ---
 
 ## Quick start
 
-### Just the skill (one feature)
-
 ```bash
 # 1. Install
-npx @viniciuscarvalho/feature-marker install
+npx skills add Viniciuscarvalho/Feature-marker
 
 # 2. Open Claude Code in your project
 
 # 3. Invoke
-/feature-marker --interactive prd-user-authentication
-```
-
-### Orchestrator (multiple features)
-
-```bash
-# 1. Install
-brew tap viniciuscarvalho/tap
-brew install feature-marker
-
-# 2. Initialize in your project
-cd your-project
-feature-marker-orchestrate init
-
-# 3. Configure
-vim .orchestrator/config.yaml    # Set source type
-cp .env.example .env && vim .env # Add API keys
-vim features.md                  # Define backlog
-
-# 4. Preview
-feature-marker-orchestrate run --dry-run
-
-# 5. Run
-feature-marker-orchestrate run
+/feature-marker prd-user-authentication
 ```

--- a/feature-marker-dist/README.md
+++ b/feature-marker-dist/README.md
@@ -40,8 +40,8 @@ Installs to `~/.claude/skills/feature-marker/`
 | --------------- | ----------------------------------------------------------------- |
 | **Full**        | Generate missing docs (PRD, TechSpec, Tasks) + execute all phases |
 | **Tasks Only**  | Use existing docs, skip generation                                |
-| **Ralph Loop**  | Autonomous execution with self-correction                         |
 | **Spec Driven** | Generate from requirements with multi-agent review                |
+| **Test Only**   | Run tests phase exclusively                                       |
 
 ## Platform Support
 

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -9,22 +9,16 @@ brew install feature-marker
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| `feature-marker-install` | Install skill to ~/.claude |
+| Command                    | Description                 |
+| -------------------------- | --------------------------- |
+| `feature-marker-install`   | Install skill to ~/.claude  |
 | `feature-marker-uninstall` | Remove skill from ~/.claude |
-| `feature-marker-orchestrate` | Run the orchestrator (new in v7.1) |
-| `feature-marker-orchestrate init` | Scaffold config in your project |
-| `feature-marker-orchestrate status` | Check orchestrator state |
-| `feature-marker-orchestrate --help` | See all options |
 
 ## Upgrade
 
 ```bash
 brew update
 brew upgrade feature-marker
-# Now feature-marker-orchestrate is available
-# Existing feature-marker-install still works identically
 ```
 
 ## Uninstall

--- a/npm/README.md
+++ b/npm/README.md
@@ -35,12 +35,12 @@ After installation, use in Claude Code:
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| `npx feature-marker install` | Install skill to ~/.claude |
+| Command                        | Description                 |
+| ------------------------------ | --------------------------- |
+| `npx feature-marker install`   | Install skill to ~/.claude  |
 | `npx feature-marker uninstall` | Remove skill from ~/.claude |
-| `npx feature-marker status` | Check installation status |
-| `npx feature-marker help` | Show help |
+| `npx feature-marker status`    | Check installation status   |
+| `npx feature-marker help`      | Show help                   |
 
 ## Features
 
@@ -48,16 +48,18 @@ After installation, use in Claude Code:
 - **4-Phase Workflow** — Analysis → Implementation → Tests → Commit & PR
 - **Checkpoint/Resume** — Pause anytime, resume where you left off
 - **Platform Detection** — Auto-detects GitHub, Azure DevOps, GitLab for PR creation
-- **Multiple Modes** — Full workflow, tasks-only, Ralph Loop, or Spec-Driven
+- **Multiple Modes** — Full workflow, tasks-only, spec-driven, or test-only
 
 ## Requirements
 
 Commands in `~/.claude/commands/`:
+
 - `create-prd.md`
 - `generate-spec.md`
 - `generate-tasks.md`
 
 Templates in `~/.claude/docs/specs/`:
+
 - `prd-template.md`
 - `techspec-template.md`
 - `tasks-template.md`


### PR DESCRIPTION
## Summary

- **README.md**: updated headline, How It Works, Key Capabilities, and Installation to reflect the skill-only model — no orchestrator, context-aware entry, four execution modes (Full, Tasks-Only, Spec-Driven, Test-Only)
- **HOW_IT_WORKS.md**: removed Path 2 (orchestrator, ~250 lines), "How the two paths relate" diagram, orchestrator quick start, `--interactive` and Ralph Loop references; modes table updated to v7 `--mode` flags
- **feature-marker-dist/README.md**: replaced Ralph Loop with Test Only in modes table
- **npm/README.md**: removed Ralph Loop from features list
- **homebrew/README.md**: removed all `feature-marker-orchestrate` commands

Orchestrator scripts were moved to an external repo in the previous commit (`fdd13de`). This cleans up all documentation that still referenced them.

## Test plan

- [ ] Read through root README — no orchestrator mentions remain
- [ ] Read through HOW_IT_WORKS.md — single-path skill flow, correct mode flags
- [ ] Verify dist/npm/homebrew READMEs no longer mention Ralph Loop or orchestrate commands