### PR TITLE
feat(v7): opt-in menu, prd-only mode, modes.json registry + 3 flow fixes

### DIFF
--- a/feature-marker-dist/HEALTH.md
+++ b/feature-marker-dist/HEALTH.md
@@ -1,0 +1,109 @@
+# feature-marker v7 Health Report
+
+> **Instructions:** Run the execution recipe in `scripts/` against a throwaway repo, then fill in each section.
+> See plan at `.claude/plans/i-need-to-check-curried-grove.md` for the full recipe.
+
+---
+
+## 1. Run Metadata
+
+| Field               | Value                                                   |
+| ------------------- | ------------------------------------------------------- |
+| Date                | —                                                       |
+| Fixture description | Add `--mode prd-only` flag parsing to feature-marker.sh |
+| Repo SHA            | —                                                       |
+| Claude Code version | —                                                       |
+| Codex CLI version   | —                                                       |
+| Gemini CLI version  | —                                                       |
+
+---
+
+## 2. Mode Matrix
+
+Pass / Fail / Skipped / N/A per phase per mode.
+
+| Mode        | Plan — PRD | Plan — Spec | Plan — Tasks | Implement | Test    | PR      |
+| ----------- | ---------- | ----------- | ------------ | --------- | ------- | ------- |
+| full        | —          | —           | —            | —         | —       | —       |
+| tasks-only  | N/A        | N/A         | N/A          | —         | —       | —       |
+| spec-driven | —          | —           | —            | —         | —       | —       |
+| test-only   | N/A        | N/A         | N/A          | N/A       | —       | —       |
+| prd-only    | —          | Skipped     | Skipped      | Skipped   | Skipped | Skipped |
+
+---
+
+## 3. Token Usage
+
+Run `scripts/scrape-tokens.sh <session-id> <project-path>` for each mode.
+
+| Mode        | Session ID | Input tokens | Output tokens | Total | Δ vs full |
+| ----------- | ---------- | ------------ | ------------- | ----- | --------- |
+| full        | —          | —            | —             | —     | baseline  |
+| tasks-only  | —          | —            | —             | —     | —         |
+| spec-driven | —          | —            | —             | —     | —         |
+| test-only   | —          | —            | —             | —     | —         |
+| prd-only    | —          | —            | —             | —     | —         |
+
+**Pass criterion:** prd-only total < 50% of full total.
+**Partial pass:** prd-only total between 50%–75% of full (document in §6).
+
+---
+
+## 4. Artifact Portability
+
+Run `scripts/lint-artifacts.sh <mode-artifacts-dir>` for each mode.
+
+| Mode        | Lint result                  | Leaked patterns (if any) |
+| ----------- | ---------------------------- | ------------------------ |
+| full        | —                            | —                        |
+| tasks-only  | —                            | —                        |
+| spec-driven | —                            | —                        |
+| test-only   | N/A (no artifacts generated) | —                        |
+| prd-only    | —                            | —                        |
+
+---
+
+## 5. Codex + Gemini Smoke
+
+Artifacts used: `full` mode (only mode guaranteed to produce all three docs from one drafter run).
+
+Invocation:
+
+```bash
+cat prd.md techspec.md tasks.md scripts/smoke-prompt.txt | codex exec -
+cat prd.md techspec.md tasks.md scripts/smoke-prompt.txt | gemini -p -
+```
+
+### Codex CLI
+
+- Version: —
+- Response:
+
+```
+(paste verbatim)
+```
+
+- Result: Pass / Fail / Skipped (CLI not installed)
+
+### Gemini CLI
+
+- Version: —
+- Response:
+
+```
+(paste verbatim)
+```
+
+- Result: Pass / Fail / Skipped (CLI not installed)
+
+**Pass criterion:** both runtimes return exactly three numbered lines matching `tasks.md`'s top-level task order.
+
+---
+
+## 6. Known Gaps
+
+<!-- Add any failures, partial passes, or observed regressions here. -->
+
+- [ ] Ralph-Loop option removed from menu (option 3 dropped; would require restoring agent mode table to re-enable).
+- [ ] Spec-driven lazy install requires `~/.claude/skills/feature-marker/resources/spec-workflow/skills/` to exist — pre-flight before running mode #3.
+- [ ] JSONL schema for session transcripts is undocumented — scraper fails loudly if shape changes.

--- a/feature-marker-dist/README.md
+++ b/feature-marker-dist/README.md
@@ -27,8 +27,8 @@ Installs to `~/.claude/skills/feature-marker/`
 # Start workflow
 /feature-marker my-feature-name
 
-# Interactive mode selection
-/feature-marker --interactive my-feature-name
+# Interactive mode selection menu (requires TTY)
+/feature-marker --menu my-feature-name   # or -i
 
 # Direct mode
 /feature-marker --mode full my-feature-name
@@ -42,6 +42,7 @@ Installs to `~/.claude/skills/feature-marker/`
 | **Tasks Only**  | Use existing docs, skip generation                                |
 | **Spec Driven** | Generate from requirements with multi-agent review                |
 | **Test Only**   | Run tests phase exclusively                                       |
+| **PRD Only**    | Draft PRD and exit; no TechSpec/Tasks/impl/PR                     |
 
 ## Platform Support
 

--- a/feature-marker-dist/agents/feature-marker.md
+++ b/feature-marker-dist/agents/feature-marker.md
@@ -17,11 +17,13 @@ Phase instructions live at `~/.claude/skills/feature-marker/agents/phases/`.
 
 Read `.claude/feature-state/{slug}/checkpoint.json` if it exists.
 
-**Checkpoint found** — read `current_phase` and `phase_status`. Show:
+**Checkpoint found** — read `current_phase`, `phase_status`, and `mode`. Show:
 
 > Checkpoint found for `{slug}`: currently at **{current_phase}** ({phase_status}). Resume here? **[yes / start fresh]**
 
 On "start fresh": delete the checkpoint file and proceed as new.
+
+**Mode precedence**: `EXECUTION_MODE` env var (set by `--mode` flag or menu selection) always wins. If `EXECUTION_MODE` is unset, use `checkpoint.mode` as the default. `phase_status=completed` still gates within-mode phases regardless of which source set the mode.
 
 **No checkpoint** — scan for the first matching signal:
 
@@ -36,7 +38,7 @@ On "start fresh": delete the checkpoint file and proceed as new.
 Show one message: what was detected + suggested entry point.
 Ask: "Proceed? **[yes / change path]**"
 
-On "change path": ask one open question — no menu, accept a free-form response.
+On "change path": ask one open question — accept a free-form response. (An opt-in menu is available via `feature-marker.sh --menu <slug>` or `-i`; the agent never invokes it automatically.)
 
 ---
 
@@ -56,9 +58,19 @@ Read `./CLAUDE.md` if present. Use its contents as project conventions throughou
 
 ## 3. Execute Phases
 
-Phases in order: **plan → implement → test → pr**
+**Before entering the loop**, read `~/.claude/skills/feature-marker/lib/modes.json` and find the entry matching `EXECUTION_MODE` (default `"full"`). Derive the run list:
 
-For each phase:
+```
+run_list = [plan, implement, test, pr]
+           starting at entry field
+           minus skipped array
+```
+
+Example: `prd-only` → `entry="plan"`, `skipped=["implement","test","pr"]` → `run_list=["plan"]`.
+
+This filter happens once, before any phase file is loaded. Never load a phase file for a phase outside `run_list`.
+
+**For each phase in run_list**:
 
 1. Check checkpoint — if status is `completed`, skip it
 2. If status is `error`, show the saved `error_state` message. Ask: "Retry this phase or skip it?"
@@ -68,15 +80,6 @@ For each phase:
    ```
 4. Follow those instructions for the feature slug `{slug}`
 5. On completion, update checkpoint: `current_phase={phase}`, `phase_status=completed`
-
-**Entry point overrides** based on detected state or user choice:
-
-| Mode           | Entry point | Skipped phases                         |
-| -------------- | ----------- | -------------------------------------- |
-| tasks-only     | implement   | plan                                   |
-| test-only      | test        | plan, implement                        |
-| spec-driven    | plan        | none (plan runs with spec_driven=true) |
-| full (default) | plan        | none                                   |
 
 **Spec-driven lazy install**: before running plan with spec-driven, verify that
 `~/.claude/skills/spec-orchestrator/SKILL.md` and `~/.claude/skills/spec-executor/SKILL.md`

--- a/feature-marker-dist/agents/phases/plan-agent.md
+++ b/feature-marker-dist/agents/phases/plan-agent.md
@@ -16,7 +16,19 @@ Check each file in `./tasks/{slug}/`. Generate only what is missing — never ov
 
 If a template is missing, stop and show the expected path. Do not proceed without all three files present.
 
+**PRD review gate** — if `prd.md` was just generated (did not exist before this run): show the full contents of `prd.md` to the user and stop. Do not invoke `/generate-spec` or `/generate-tasks` until the user explicitly replies "looks good" (or equivalent approval). If the user requests edits, apply them to `prd.md` and show the updated file again. Repeat until approved.
+
 **Plan context** — check `~/.claude/plans/` for the most recently modified `.md` file. If found, present its contents when invoking `/create-prd` with this framing: "The following plan covers problem definition, constraints, and scope. Use it as pre-answered context and reduce clarifying questions to only items not covered." This is non-blocking if absent.
+
+---
+
+## PRD-Only Variant
+
+When `EXECUTION_MODE=prd-only` (check `~/.claude/skills/feature-marker/lib/modes.json` — `skipped` includes `implement`, `test`, `pr`):
+
+1. Run only the `prd.md` row of the Inputs Gate (invoke `/create-prd`).
+2. Skip TechSpec, Tasks, Spec-Driven, Product-Manager check, and Analysis sections below.
+3. Update checkpoint: `current_phase=plan`, `phase_status=completed`, `"mode": "prd-only"`.
 
 ---
 

--- a/feature-marker-dist/agents/phases/pr-agent.md
+++ b/feature-marker-dist/agents/phases/pr-agent.md
@@ -16,17 +16,11 @@ Check if `~/.claude/commands/commit.md` exists.
 
 ## PR Creation
 
-Detect the git platform from the remote URL:
+Resolve the PR skill using this priority order:
 
-| Remote URL pattern | Skill         |
-| ------------------ | ------------- |
-| `github.com`       | `checking-pr` |
-| `dev.azure.com`    | `azure-pr`    |
-| `gitlab.com`       | `checking-pr` |
-| `bitbucket.org`    | `checking-pr` |
-| anything else      | `checking-pr` |
-
-Check `.feature-marker.json` for a `pr_skill` override. If set, use that instead.
+1. `pr_skill` field in `.feature-marker.json` — highest priority override
+2. `PR_SKILL` env var — exported by `feature-marker.sh` after platform detection
+3. Re-detect from git remote URL using `~/.claude/skills/feature-marker/lib/platform-detector.sh`
 
 If `skip_pr` is `true` in `.feature-marker.json`, skip PR creation and log instructions for manual creation.
 
@@ -36,8 +30,11 @@ Invoke the selected skill. If the skill is unavailable, commit only and show the
 
 ## Outputs
 
-Save the PR URL to `.claude/feature-state/{slug}/pr-url.txt`.
+After invoking the PR skill, read `.claude/feature-state/{slug}/pr-url.txt`.
 
-Update checkpoint: `current_phase=pr`, `phase_status=completed`.
+If the file is missing or its content does not start with `https://`: the PR creation failed. Show the raw skill output to the user. Do **not** update the checkpoint. Ask: "Retry PR creation or create the PR manually?"
 
-Show the PR URL to the user and confirm the feature is complete.
+If the URL is valid:
+
+- Update checkpoint: `current_phase=pr`, `phase_status=completed`.
+- Show the PR URL to the user and confirm the feature is complete.

--- a/feature-marker-dist/feature-marker/SKILL.md
+++ b/feature-marker-dist/feature-marker/SKILL.md
@@ -51,7 +51,7 @@ The skill reads project state on every invocation and presents a single confirma
 - Nothing found → starts from PRD generation
 
 For programmatic use: `/feature-marker --mode <mode> <feature-slug>`
-where mode is one of: `full` · `tasks-only` · `spec-driven` · `test-only`
+where mode is one of: `full` · `tasks-only` · `spec-driven` · `test-only` · `prd-only`
 
 ## Prerequisites
 

--- a/feature-marker-dist/feature-marker/feature-marker.sh
+++ b/feature-marker-dist/feature-marker/feature-marker.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source "${SCRIPT_DIR}/lib/ui.sh"
 source "${SCRIPT_DIR}/lib/config.sh"
+source "${SCRIPT_DIR}/lib/modes.sh"
 source "${SCRIPT_DIR}/lib/state-manager.sh"
 source "${SCRIPT_DIR}/lib/platform-detector.sh"
 
@@ -16,6 +17,7 @@ banner
 FEATURE_NAME=""
 SHOW_HELP=false
 SHOW_STATUS=false
+MENU_REQUESTED=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -40,6 +42,10 @@ while [[ $# -gt 0 ]]; do
       export EXECUTION_MODE
       shift 2
       ;;
+    --menu|-i)
+      MENU_REQUESTED=true
+      shift
+      ;;
     -*)
       error "Unknown option: $1"
       exit 1
@@ -61,7 +67,8 @@ if [[ "${SHOW_HELP}" == "true" ]]; then
   echo "  -h, --help          Show this help"
   echo "  -s, --status        Show checkpoint status for a feature"
   echo "  -p, --platform      Show detected platform info"
-  echo "  -m, --mode <mode>   Execution mode: full | tasks-only | spec-driven | test-only"
+  echo "  -m, --mode <mode>   Execution mode: $(get_modes_help_string)"
+  echo "  -i, --menu          Open interactive mode-selection menu (requires TTY)"
   echo "  -V, --version       Show version"
   exit 0
 fi
@@ -72,6 +79,12 @@ if [[ "${SHOW_STATUS}" == "true" ]]; then
   exit 0
 fi
 
+if [[ "${MENU_REQUESTED}" == "true" ]]; then
+  [[ -z "${FEATURE_NAME}" ]] && { error "Feature name required for --menu"; exit 1; }
+  source "${SCRIPT_DIR}/lib/menu.sh"
+  select_execution_mode "${FEATURE_NAME}"
+fi
+
 if [[ -z "${FEATURE_NAME}" ]]; then
   error "Feature name required"
   echo "Usage: feature-marker.sh <feature-slug>"
@@ -80,6 +93,7 @@ if [[ -z "${FEATURE_NAME}" ]]; then
 fi
 
 load_config
+
 validate_git_repo || exit 1
 
 header "Feature: ${FEATURE_NAME}"
@@ -87,6 +101,22 @@ separator
 
 validate_directories "${FEATURE_NAME}"
 init_feature_state "${FEATURE_NAME}"
+
+# If no --mode flag was passed, fall back to the mode stored in the checkpoint.
+if [[ -z "${EXECUTION_MODE:-}" ]] && checkpoint_exists "${FEATURE_NAME}"; then
+  stored_mode="$(get_checkpoint_mode "${FEATURE_NAME}")"
+  if [[ -n "$stored_mode" ]]; then
+    export EXECUTION_MODE="$stored_mode"
+    info "Resuming with checkpoint mode: ${EXECUTION_MODE}"
+  fi
+fi
+
+# Validate and persist the resolved mode.
+if [[ -n "${EXECUTION_MODE:-}" ]]; then
+  assert_valid_mode "${EXECUTION_MODE}"
+  validate_mode_requirements "${EXECUTION_MODE}"
+  set_checkpoint_mode "${FEATURE_NAME}" "${EXECUTION_MODE}"
+fi
 
 if checkpoint_exists "${FEATURE_NAME}"; then
   show_checkpoint_summary "${FEATURE_NAME}"
@@ -96,4 +126,5 @@ fi
 
 separator
 show_platform_info
+export PR_SKILL="$(get_pr_skill_for_platform)"
 separator

--- a/feature-marker-dist/feature-marker/lib/menu.sh
+++ b/feature-marker-dist/feature-marker/lib/menu.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# menu.sh - Interactive menu for feature-marker
+set -euo pipefail
+
+# Check if TTY is available for interactive input
+check_tty_available() {
+  if [[ -t 0 ]] && [[ -t 1 ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# Display main menu panel
+show_main_menu() {
+  local feature_name="$1"
+
+  echo ""
+  echo -e "${BOLD}┌──────────────────────────────────────────────────────┐${NC}"
+  echo -e "${BOLD}│         🚀 Feature Marker - Execution Mode           │${NC}"
+  echo -e "${BOLD}└──────────────────────────────────────────────────────┘${NC}"
+  echo ""
+  echo -e "  ${BOLD}Feature:${NC} ${BLUE}${feature_name}${NC}"
+  echo ""
+  echo -e "  ${BOLD}Select execution mode:${NC}"
+  echo ""
+  echo -e "  ${GREEN}1)${NC} ${BOLD}Full Workflow${NC} - Generate PRD/TechSpec/Tasks + Implementation"
+  echo -e "     ${BLUE}→${NC} Creates missing files and executes all phases"
+  echo ""
+  echo -e "  ${GREEN}2)${NC} ${BOLD}Execute Tasks Only${NC} - Skip generation, run implementation"
+  echo -e "     ${BLUE}→${NC} Use existing PRD/TechSpec/Tasks (must exist)"
+  echo ""
+  echo -e "  ${GREEN}3)${NC} ${BOLD}Spec-Driven Mode${NC} - Multi-agent review + worktree isolation"
+  echo -e "     ${BLUE}→${NC} Uses spec-workflow for rigorous spec review"
+  echo ""
+  echo -e "  ${GREEN}4)${NC} ${BOLD}Test Only Mode${NC} - Run tests phase exclusively"
+  echo -e "     ${BLUE}→${NC} Uses platform-appropriate test guidance (Swift Testing, Jest, pytest, etc.)"
+  echo ""
+  echo -e "  ${GREEN}5)${NC} ${BOLD}PRD Only${NC} - Draft PRD and exit"
+  echo -e "     ${BLUE}→${NC} Skips TechSpec, Tasks, branch, implementation, PR"
+  echo ""
+  echo -e "  ${YELLOW}0)${NC} Exit"
+  echo ""
+}
+
+# Display execution mode confirmation
+confirm_mode() {
+  local mode="$1"
+  local feature_name="$2"
+
+  echo ""
+  case "$mode" in
+    1)
+      echo -e "${BOLD}📋 Full Workflow Mode${NC}"
+      echo "  • Validates existing files"
+      echo "  • Generates missing PRD/TechSpec/Tasks"
+      echo "  • Executes all 4 phases"
+      ;;
+    2)
+      echo -e "${BOLD}⚡ Execute Tasks Only Mode${NC}"
+      echo "  • Skips file generation"
+      echo "  • Requires existing PRD/TechSpec/Tasks"
+      echo "  • Goes directly to implementation"
+      ;;
+    3)
+      echo -e "${BOLD}🔬 Spec-Driven Mode${NC}"
+      echo "  • Multi-agent review of specifications"
+      echo "  • Isolated worktree for safe development"
+      echo "  • Converts spec to PRD/TechSpec/Tasks format"
+      echo "  • Then executes standard FM phases 3-4"
+      ;;
+    4)
+      echo -e "${BOLD}🧪 Test Only Mode${NC}"
+      echo "  • Runs only the test phase (Phase 3)"
+      echo "  • Uses /swift-testing skill for guided test creation"
+      echo "  • Validates existing implementation with tests"
+      echo "  • Skips generation, planning, and implementation"
+      ;;
+    5)
+      echo -e "${BOLD}📝 PRD Only Mode${NC}"
+      echo "  • Drafts PRD.md via /create-prd"
+      echo "  • Exits before TechSpec/Tasks generation"
+      echo "  • No branch, no implementation, no PR"
+      echo "  • Artifacts are portable — consumable by any LLM"
+      ;;
+  esac
+  echo ""
+}
+
+# Check if spec-workflow skills are available
+check_spec_workflow_available() {
+  local skills_dir="${SKILLS_DIR:-${HOME}/.claude/skills}"
+
+  if [[ -f "${skills_dir}/spec-orchestrator/SKILL.md" ]] && \
+     [[ -f "${skills_dir}/spec-executor/SKILL.md" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+# Get bundled spec-workflow skills path
+get_bundled_spec_workflow_path() {
+  local bundled_path=""
+
+  # Priority 1: Installed feature-marker skill location
+  if [[ -d "${SKILLS_DIR:-${HOME}/.claude/skills}/feature-marker/resources/spec-workflow/skills" ]]; then
+    bundled_path="${SKILLS_DIR:-${HOME}/.claude/skills}/feature-marker/resources/spec-workflow/skills"
+  # Priority 2: FEATURE_MARKER_ROOT environment variable
+  elif [[ -n "${FEATURE_MARKER_ROOT:-}" ]] && [[ -d "${FEATURE_MARKER_ROOT}/resources/spec-workflow/skills" ]]; then
+    bundled_path="${FEATURE_MARKER_ROOT}/resources/spec-workflow/skills"
+  # Priority 3: Script directory (for development)
+  elif [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -d "${script_dir}/../resources/spec-workflow/skills" ]]; then
+      bundled_path="${script_dir}/../resources/spec-workflow/skills"
+    fi
+  fi
+
+  echo "$bundled_path"
+}
+
+# Install spec-workflow skills from bundled resources
+install_spec_workflow_skills() {
+  local target_dir="${SKILLS_DIR:-${HOME}/.claude/skills}"
+  local skills=("idea-explorer" "spec-writer" "spec-orchestrator" "spec-executor" "create-worktree" "spec-workflow-init")
+
+  local source_dir
+  source_dir="$(get_bundled_spec_workflow_path)"
+
+  if [[ -n "${SPEC_WORKFLOW_SOURCE:-}" ]]; then
+    source_dir="${SPEC_WORKFLOW_SOURCE}"
+  fi
+
+  if [[ -z "$source_dir" ]] || [[ ! -d "$source_dir" ]]; then
+    error "spec-workflow skills not found in bundled resources"
+    echo "Expected location: ~/.claude/skills/feature-marker/resources/spec-workflow/skills"
+    return 1
+  fi
+
+  info "Installing spec-workflow skills from bundled resources..."
+
+  mkdir -p "$target_dir"
+  for skill in "${skills[@]}"; do
+    if [[ -d "${source_dir}/${skill}" ]] && [[ ! -d "${target_dir}/${skill}" ]]; then
+      cp -r "${source_dir}/${skill}" "${target_dir}/"
+      success "Installed: ${skill}"
+    fi
+  done
+
+  return 0
+}
+
+# Show spec-workflow installation instructions
+show_spec_workflow_install_instructions() {
+  echo ""
+  error "Spec-Driven Mode requires spec-workflow skills"
+  echo ""
+  echo "Required skills:"
+  echo "  • spec-orchestrator"
+  echo "  • spec-executor"
+  echo "  • idea-explorer"
+  echo "  • spec-writer"
+  echo "  • create-worktree"
+  echo ""
+  echo "Would you like to install them automatically?"
+}
+
+# Interactive menu selection
+select_execution_mode() {
+  local feature_name="$1"
+  local selected_mode=""
+
+  # Check if TTY is available
+  if ! check_tty_available; then
+    # Output marker for agent to detect and use AskUserQuestion
+    echo "INTERACTIVE_MODE_REQUESTED"
+    echo "FEATURE_NAME=${feature_name}"
+    exit 100
+  fi
+
+  # Show existing feature state so the user has context before picking a mode.
+  if checkpoint_exists "${feature_name}"; then
+    show_checkpoint_summary "${feature_name}"
+    echo ""
+  fi
+
+  while true; do
+    clear
+    banner
+    show_main_menu "$feature_name"
+
+    read -p "Select option [0-5]: " selected_mode
+
+    case "$selected_mode" in
+      1)
+        confirm_mode 1 "$feature_name"
+        if ask_yes_no "Proceed with Full Workflow mode?"; then
+          export EXECUTION_MODE="full"
+          return 0
+        fi
+        ;;
+      2)
+        if validate_mode_requirements "tasks-only"; then
+          confirm_mode 2 "$feature_name"
+          if ask_yes_no "Proceed with Tasks Only mode?"; then
+            export EXECUTION_MODE="tasks-only"
+            return 0
+          fi
+        fi
+        read -p "Press Enter to continue..."
+        ;;
+      3)
+        if check_spec_workflow_available; then
+          confirm_mode 3 "$feature_name"
+          if ask_yes_no "Proceed with Spec-Driven mode?"; then
+            export EXECUTION_MODE="spec-driven"
+            return 0
+          fi
+        else
+          show_spec_workflow_install_instructions
+          if ask_yes_no "Install spec-workflow skills now?"; then
+            if install_spec_workflow_skills; then
+              success "Spec-workflow skills installed successfully!"
+              confirm_mode 3 "$feature_name"
+              if ask_yes_no "Proceed with Spec-Driven mode?"; then
+                export EXECUTION_MODE="spec-driven"
+                return 0
+              fi
+            else
+              error "Failed to install spec-workflow skills."
+            fi
+          fi
+          read -p "Press Enter to continue..."
+        fi
+        ;;
+      4)
+        confirm_mode 4 "$feature_name"
+        if ask_yes_no "Proceed with Test Only mode?"; then
+          export EXECUTION_MODE="test-only"
+          return 0
+        fi
+        ;;
+      5)
+        confirm_mode 5 "$feature_name"
+        if ask_yes_no "Proceed with PRD Only mode?"; then
+          export EXECUTION_MODE="prd-only"
+          return 0
+        fi
+        ;;
+      0)
+        echo ""
+        info "Exiting feature-marker"
+        exit 0
+        ;;
+      *)
+        error "Invalid option. Please select 0-5."
+        sleep 1
+        ;;
+    esac
+  done
+}
+
+# Export execution mode status
+get_execution_mode() {
+  echo "${EXECUTION_MODE:-full}"
+}
+
+# Check if mode is tasks-only
+is_tasks_only_mode() {
+  [[ "${EXECUTION_MODE:-full}" == "tasks-only" ]]
+}
+
+# Check if mode is full workflow
+is_full_workflow_mode() {
+  [[ "${EXECUTION_MODE:-full}" == "full" ]]
+}
+
+# Check if mode is spec-driven
+is_spec_driven_mode() {
+  [[ "${EXECUTION_MODE:-full}" == "spec-driven" ]]
+}
+
+# Check if mode is test-only
+is_test_only_mode() {
+  [[ "${EXECUTION_MODE:-full}" == "test-only" ]]
+}
+
+# Check if mode is prd-only
+is_prd_only_mode() {
+  [[ "${EXECUTION_MODE:-full}" == "prd-only" ]]
+}

--- a/feature-marker-dist/feature-marker/lib/modes.json
+++ b/feature-marker-dist/feature-marker/lib/modes.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "full",
+    "entry": "plan",
+    "skipped": [],
+    "menu_label": "Full Workflow",
+    "menu_description": "Generate PRD/TechSpec/Tasks + Implementation",
+    "menu_detail": "Creates missing files and executes all phases",
+    "menu_opt": 1,
+    "requires": []
+  },
+  {
+    "id": "tasks-only",
+    "entry": "implement",
+    "skipped": [
+      "plan"
+    ],
+    "menu_label": "Execute Tasks Only",
+    "menu_description": "Skip generation, run implementation",
+    "menu_detail": "Use existing PRD/TechSpec/Tasks (must exist)",
+    "menu_opt": 2,
+    "requires": [
+      "prd.md",
+      "techspec.md",
+      "tasks.md"
+    ]
+  },
+  {
+    "id": "spec-driven",
+    "entry": "plan",
+    "skipped": [],
+    "menu_label": "Spec-Driven Mode",
+    "menu_description": "Multi-agent review + worktree isolation",
+    "menu_detail": "Uses spec-workflow for rigorous spec review",
+    "menu_opt": 3,
+    "requires": []
+  },
+  {
+    "id": "test-only",
+    "entry": "test",
+    "skipped": [
+      "plan",
+      "implement"
+    ],
+    "menu_label": "Test Only Mode",
+    "menu_description": "Run tests phase exclusively",
+    "menu_detail": "Uses platform-appropriate test guidance (Swift Testing, Jest, pytest, etc.)",
+    "menu_opt": 4,
+    "requires": []
+  },
+  {
+    "id": "prd-only",
+    "entry": "plan",
+    "skipped": [
+      "implement",
+      "test",
+      "pr"
+    ],
+    "menu_label": "PRD Only",
+    "menu_description": "Draft PRD and exit",
+    "menu_detail": "Skips TechSpec, Tasks, branch, implementation, PR",
+    "menu_opt": 5,
+    "requires": []
+  }
+]

--- a/feature-marker-dist/feature-marker/lib/modes.sh
+++ b/feature-marker-dist/feature-marker/lib/modes.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# modes.sh - Single source of truth for execution mode metadata.
+# Reads lib/modes.json; all mode logic routes through here.
+set -euo pipefail
+
+MODES_JSON="${SCRIPT_DIR}/lib/modes.json"
+
+# Print newline-separated list of valid mode IDs.
+get_valid_modes() {
+  jq -r '.[].id' "$MODES_JSON"
+}
+
+# Print pipe-separated mode IDs for help text (e.g. "full | tasks-only | ...").
+get_modes_help_string() {
+  jq -r '[.[].id] | join(" | ")' "$MODES_JSON"
+}
+
+# Exit 1 with error if the given mode ID is not in modes.json.
+assert_valid_mode() {
+  local mode="$1"
+  local match
+  match=$(jq -r --arg m "$mode" '.[] | select(.id == $m) | .id' "$MODES_JSON")
+  if [[ -z "$match" ]]; then
+    error "Unknown mode: '${mode}'"
+    echo "  Valid modes: $(get_modes_help_string)"
+    exit 1
+  fi
+}
+
+# Validate that required files exist for the given mode.
+# Reads the 'requires' array from modes.json.
+# Exits 1 with a clear error if any file is missing.
+validate_mode_requirements() {
+  local mode="$1"
+  local feature_path="${DOCS_PATH:-./tasks}/${FEATURE_NAME:-}"
+
+  local missing=()
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    [[ ! -f "${feature_path}/${f}" ]] && missing+=("$f")
+  done < <(jq -r --arg m "$mode" '.[] | select(.id == $m) | .requires[]' "$MODES_JSON" 2>/dev/null)
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    error "Mode '${mode}' requires files that don't exist in ${feature_path}/:"
+    for f in "${missing[@]}"; do
+      echo "  • ${f}"
+    done
+    echo ""
+    echo "Run with --mode full to generate missing files first."
+    return 1
+  fi
+}
+
+# Read a single field from the mode entry (e.g. get_mode_field tasks-only entry → "implement").
+get_mode_field() {
+  local mode="$1"
+  local field="$2"
+  jq -r --arg m "$mode" --arg f "$field" '.[] | select(.id == $m) | .[$f] // empty' "$MODES_JSON"
+}

--- a/feature-marker-dist/feature-marker/lib/platform-detector.sh
+++ b/feature-marker-dist/feature-marker/lib/platform-detector.sh
@@ -2,10 +2,11 @@
 # platform-detector.sh - Git platform detection for feature-marker
 set -euo pipefail
 
-# Detect git platform from remote URL
+# Detect git platform from remote URL.
+# Set FEATURE_MARKER_GIT_REMOTE to inject a fake URL in tests.
 detect_git_platform() {
   local remote_url
-  remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+  remote_url="${FEATURE_MARKER_GIT_REMOTE:-$(git remote get-url origin 2>/dev/null || echo "")}"
 
   if [[ -z "$remote_url" ]]; then
     echo "unknown"

--- a/feature-marker-dist/feature-marker/lib/state-manager.sh
+++ b/feature-marker-dist/feature-marker/lib/state-manager.sh
@@ -21,6 +21,7 @@ init_feature_state() {
   "version": "7.0.0",
   "feature_name": "${feature_name}",
   "project_path": "$(pwd)",
+  "mode": null,
   "current_phase": "plan",
   "phase_status": "pending",
   "spec_driven": false,
@@ -35,6 +36,31 @@ init_feature_state() {
 }
 EOF
     echo "Created checkpoint: $checkpoint"
+  fi
+}
+
+# Set the execution mode in checkpoint (called when mode is first established)
+set_checkpoint_mode() {
+  local feature_name="$1"
+  local mode="$2"
+  local checkpoint="${STATE_PATH}/${feature_name}/checkpoint.json"
+
+  if [[ -f "$checkpoint" ]]; then
+    local tmp=$(mktemp)
+    jq --arg mode "$mode" --arg now "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" '
+      .mode = $mode |
+      .last_updated = $now
+    ' "$checkpoint" > "$tmp" && mv "$tmp" "$checkpoint"
+  fi
+}
+
+# Get the execution mode stored in checkpoint (empty string if not set)
+get_checkpoint_mode() {
+  local feature_name="$1"
+  local checkpoint="${STATE_PATH}/${feature_name}/checkpoint.json"
+
+  if [[ -f "$checkpoint" ]]; then
+    jq -r '.mode // empty' "$checkpoint"
   fi
 }
 
@@ -154,6 +180,8 @@ show_checkpoint_summary() {
 
   if [[ -f "$checkpoint" ]]; then
     echo "Checkpoint found for: $feature_name"
+    local mode=$(jq -r '.mode // empty' "$checkpoint")
+    [[ -n "$mode" ]] && echo "  Mode: $mode"
     echo "  Current phase: $(jq -r '.current_phase' "$checkpoint")"
     echo "  Status: $(jq -r '.phase_status' "$checkpoint")"
     echo "  Last updated: $(jq -r '.last_updated' "$checkpoint")"

--- a/feature-marker-dist/scripts/lint-artifacts.sh
+++ b/feature-marker-dist/scripts/lint-artifacts.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Usage: lint-artifacts.sh <dir>
+# Exit 0 = clean (no Claude-isms), Exit 1 = leaks found
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: lint-artifacts.sh <artifacts-dir>" >&2
+  exit 1
+fi
+
+dir="$1"
+
+if [[ ! -d "$dir" ]]; then
+  echo "ERROR: directory not found: $dir" >&2
+  exit 1
+fi
+
+# Patterns that should never appear in portable artifacts
+patterns='/spec-orchestrator|/spec-executor|/idea-explorer|/spec-writer|/swift-testing|/create-prd|/generate-spec|/generate-tasks|/commit|/feature-marker|<command-name>|Use the [A-Z][a-zA-Z-]* (agent|skill)'
+
+hits=$(grep -REn "$patterns" "$dir" 2>/dev/null || true)
+
+if [[ -n "$hits" ]]; then
+  echo "LEAKS FOUND in $dir:"
+  echo "$hits"
+  exit 1
+fi
+
+echo "clean: $dir"
+exit 0

--- a/feature-marker-dist/scripts/scrape-tokens.sh
+++ b/feature-marker-dist/scripts/scrape-tokens.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Usage: scrape-tokens.sh <session-id> [project-abs-path]
+# Prints: <input_tokens>\t<output_tokens>\t<total>
+# Requires: jq
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: scrape-tokens.sh <session-id> [project-abs-path]" >&2
+  exit 1
+fi
+
+sid="$1"
+proj="${2:-$(pwd)}"
+encoded="${proj//\//-}"
+jsonl="${HOME}/.claude/projects/${encoded}/${sid}.jsonl"
+
+if [[ ! -f "$jsonl" ]]; then
+  echo "ERROR: session file not found: $jsonl" >&2
+  exit 1
+fi
+
+jq -rs '
+  map(select(.type == "assistant" and .message.usage != null))
+  | if length == 0 then error("no assistant turns with usage found")
+    else
+      { input:  (map(.message.usage.input_tokens  // 0) | add),
+        output: (map(.message.usage.output_tokens // 0) | add) }
+      | if (.input + .output) == 0 then error("total tokens is 0 — check session ID")
+        else "\(.input)\t\(.output)\t\(.input + .output)"
+        end
+    end
+' "$jsonl"

--- a/feature-marker-dist/scripts/smoke-prompt.txt
+++ b/feature-marker-dist/scripts/smoke-prompt.txt
@@ -1,0 +1,1 @@
+You are reading a PRD, a Tech Spec, and a Tasks document for one feature. List the first 3 tasks in execution order. Reply with exactly three numbered lines and nothing else.


### PR DESCRIPTION
## Summary

- **Opt-in menu** (`--menu` / `-i`): restores mode-selection UI as an explicit flag; agent default (one open question) is unchanged
- **prd-only mode**: runs only `/create-prd`, skips techspec/tasks/implement/test/pr — the token-saving short-circuit
- **modes.json registry**: single source of truth for all mode metadata (entry, skipped, requires); both bash and agent derive from it
- **Three flow fixes** from a systematic break-point audit: PRD review gate, PR nil-check, menu checkpoint context

## What changed

### New
- `lib/menu.sh` — opt-in interactive mode selector (restored from v6, stripped of Ralph Loop, added prd-only option)
- `lib/modes.json` — canonical mode registry (id, entry, skipped, requires, menu metadata)
- `lib/modes.sh` — bash helpers: `assert_valid_mode`, `validate_mode_requirements`, `get_mode_field`
- `scripts/scrape-tokens.sh` — reads session JSONL, sums input/output tokens per mode
- `scripts/lint-artifacts.sh` — greps for Claude-isms in generated artifacts (exit 0 = clean)
- `scripts/smoke-prompt.txt` — fixed one-shot prompt for Codex/Gemini artifact portability test
- `HEALTH.md` — health-check report skeleton (to be filled after run-day)

### Modified
- `feature-marker.sh` — adds `--menu`/`-i` flag; reads checkpoint mode as default when no `--mode` passed; exports `PR_SKILL`
- `lib/state-manager.sh` — checkpoint gains `mode` field; adds `set_checkpoint_mode` / `get_checkpoint_mode`
- `lib/platform-detector.sh` — `FEATURE_MARKER_GIT_REMOTE` env var for test injection
- `agents/feature-marker.md` — mode precedence rule; phase loop derives run_list from modes.json before loading any file
- `agents/phases/plan-agent.md` — PRD review gate + prd-only variant
- `agents/phases/pr-agent.md` — PR URL nil-check; collapsed duplicate platform table
- `SKILL.md`, `README.md` — updated for new flags and modes

## Bug fixes

| # | Bug | Fix |
|---|-----|-----|
| #2 | PRD flows straight into techspec with no user review | Hard gate: show PRD, require "looks good" before `/generate-spec` |
| #3 | `gh pr create` failure silently flips checkpoint to `completed` | Read `pr-url.txt` after skill runs; skip checkpoint update if URL missing or invalid |
| #1 | `--menu` on in-progress feature shows blank mode picker with no context | Call `show_checkpoint_summary` before the mode loop |

## Test plan

- [ ] `feature-marker.sh --help` lists `--menu` / `-i` and shows `prd-only` in mode line
- [ ] Running with no flags never prints the menu banner
- [ ] Running with `--menu` on a fresh feature shows mode picker
- [ ] Running with `--menu` on a feature with a checkpoint shows checkpoint state before mode picker
- [ ] `--mode prd-only` runs only plan phase, stops after PRD draft, no techspec/tasks generated
- [ ] PRD gate: generating a new PRD pauses and waits for user approval before techspec
- [ ] PR phase: when PR skill fails, checkpoint stays at `phase_status=pending`, user is prompted
- [ ] `FEATURE_MARKER_GIT_REMOTE=https://github.com/x/y feature-marker.sh slug` detects github without a real remote
