### PR TITLE
docs(readme): explain skill-first workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Expanded README quick start, Homebrew install, and code-derived workflow
+  explanation for new users.
+
 ## [7.8.1] - 2026-05-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,9 +29,36 @@ workflow, own feature state, push branches, or open pull requests.
 - Stops at a clean local branch handoff. You stay in control of push and PR
   creation.
 
-## Install With npx
+## Quick Start
 
-Install for Claude:
+Install the skill files:
+
+```bash
+npx -y @viniciuscarvalho/feature-marker install --runtime all
+```
+
+Open any git project in Claude, Codex, or Gemini and ask:
+
+```text
+Use feature-marker to implement my-feature.
+```
+
+feature-marker will create or reuse:
+
+```text
+tasks/my-feature/prd.md
+tasks/my-feature/techspec.md
+tasks/my-feature/tasks.md
+```
+
+Then it works through the feature, verifies it, commits locally, and prints the
+exact commands you can run to push and open a PR.
+
+## Install
+
+Use `npx` when you want the latest npm installer without a global install.
+
+Install only Claude:
 
 ```bash
 npx -y @viniciuscarvalho/feature-marker install --runtime claude
@@ -56,11 +83,19 @@ Use `--dry-run` to preview install targets:
 npx -y @viniciuscarvalho/feature-marker install --runtime all --dry-run
 ```
 
-Global npm install is optional and only shortens the installer command:
+Global npm install is optional and only shortens the command:
 
 ```bash
 npm install -g @viniciuscarvalho/feature-marker
 feature-marker install --runtime codex
+```
+
+Homebrew is also supported on macOS/Linux:
+
+```bash
+brew tap viniciuscarvalho/tap
+brew install feature-marker
+feature-marker install --runtime all
 ```
 
 ## Use In Your LLM
@@ -99,6 +134,23 @@ PRD, TechSpec, and Tasks are created from bundled templates installed with the
 skill. The agent fills `{slug}` and `{feature_title}` and writes:
 `tasks/{slug}/prd.md`, `tasks/{slug}/techspec.md`, and
 `tasks/{slug}/tasks.md`.
+
+## How It Works
+
+The published package contains a small installer CLI and the skill files. The
+code path is intentionally narrow:
+
+1. `feature-marker install --runtime ...` resolves the package root and the
+   user's home directory.
+2. It copies the selected runtime skill to its native skill folder.
+3. It copies the shared PRD, TechSpec, and Tasks templates into that install.
+4. For Claude, it also installs the companion agent wrapper.
+5. The actual feature workflow runs later inside Claude, Codex, or Gemini when
+   the user asks to use `feature-marker`.
+
+The CLI does not implement the feature workflow. Commands such as `run`,
+`resume`, `status`, and `capabilities` intentionally fail with guidance to
+invoke the installed skill from the LLM prompt.
 
 ## Installer Commands
 

--- a/tests/feature-marker.test.js
+++ b/tests/feature-marker.test.js
@@ -119,6 +119,13 @@ test('README and skill docs describe npx install plus LLM invocation', () => {
 
   assert.match(readme, /npx -y @viniciuscarvalho\/feature-marker install --runtime all/);
   assert.match(readme, /npx -y @viniciuscarvalho\/feature-marker install --runtime claude/);
+  assert.match(readme, /## Quick Start/);
+  assert.match(readme, /Use feature-marker to implement my-feature/);
+  assert.match(readme, /tasks\/my-feature\/prd\.md/);
+  assert.match(readme, /brew tap viniciuscarvalho\/tap/);
+  assert.match(readme, /brew install feature-marker/);
+  assert.match(readme, /The published package contains a small installer CLI and the skill files/);
+  assert.match(readme, /Commands such as `run`,\s+`resume`, `status`, and `capabilities` intentionally fail/);
   assert.match(readme, /assets\/skill-first-flow\.svg/);
   assert.match(readme, /Why Star This Repo/);
   assert.match(readme, /Claude prompt:/);


### PR DESCRIPTION
## Summary

- Makes the README easier for new users by adding a short Quick Start and Homebrew install path.
- Explains the feature-marker workflow from the actual installer code: install skill files, invoke from the LLM, keep artifacts in `tasks/{slug}`, and stop at branch handoff.

## Changes

- **README:** Adds Quick Start, Homebrew install instructions, and a code-derived How It Works section covering runtime copy targets, templates, Claude agent wrapper, and unsupported workflow CLI commands.
- **Tests:** Extends static README assertions so Quick Start, Homebrew, and code-derived workflow guidance stay documented.
- **Changelog:** Notes the README expansion under Unreleased.

## Release Notes

### 📚 Documentation

- *(readme)* Explain skill-first workflow for new users

## Test plan

- [x] `npm test`
- [x] `npm pack --dry-run --json`
- [x] `node bin/cli.js --version`
- [x] `node bin/cli.js install --runtime all --dry-run`
